### PR TITLE
fix: remove unused default value assignments for optional parameters

### DIFF
--- a/Either/Either.mbti
+++ b/Either/Either.mbti
@@ -3,6 +3,8 @@ package "Kaida-Amethyst/MoonLLVM/Either"
 
 // Values
 
+// Errors
+
 // Types and methods
 pub(all) enum Either[L, R] {
   Left(L)

--- a/IR/BasicBlock.mbt
+++ b/IR/BasicBlock.mbt
@@ -38,7 +38,7 @@ pub struct BasicBlock {
 }
 
 ///|
-fn BasicBlock::new(parent : Function, name~ : String? = None) -> BasicBlock {
+fn BasicBlock::new(parent : Function, name~ : String?) -> BasicBlock {
   let uid = valueUIDAssigner.assign()
   BasicBlock::{
     uid,

--- a/IR/DataLayout.mbt
+++ b/IR/DataLayout.mbt
@@ -1,5 +1,5 @@
 ///|
-type Align UInt64 derive(Eq)
+struct Align(UInt64) derive(Eq)
 
 ///|
 pub fn Align::new(v : UInt64) -> Align {

--- a/IR/IR.mbti
+++ b/IR/IR.mbti
@@ -11,6 +11,13 @@ import(
 // Values
 fn warning_elimination() -> Unit
 
+// Errors
+type LLVMTypeError
+impl Show for LLVMTypeError
+
+pub suberror LLVMValueError String
+impl Show for LLVMValueError
+
 // Types and methods
 pub enum AbstractTypeEnum {
   VoidType(VoidType)
@@ -21,7 +28,7 @@ pub enum AbstractTypeEnum {
 }
 impl Show for AbstractTypeEnum
 
-pub type AddressSpace UInt
+pub struct AddressSpace(UInt)
 fn AddressSpace::inner(Self) -> UInt
 fn AddressSpace::new(UInt) -> Self
 impl Default for AddressSpace
@@ -403,7 +410,7 @@ pub struct Context {
   key : UInt
   // private fields
 }
-fn Context::addModule(Self, String, source_file~ : String? = ..) -> Module
+fn Context::addModule(Self, String, source_file? : String?) -> Module
 fn Context::createBuilder(Self) -> IRBuilder
 fn Context::getArrayType(Self, &Type, UInt) -> ArrayType raise LLVMTypeError
 fn Context::getBFloatTy(Self) -> BFloatType
@@ -415,8 +422,8 @@ fn Context::getConstFalse(Self) -> ConstantInt
 fn Context::getConstFloat(Self, Double) -> ConstantFP
 fn Context::getConstFloatArray(Self, Array[Float]) -> ConstantArray
 fn Context::getConstFloatVector(Self, Array[Float]) -> ConstantVector
-fn Context::getConstInfDouble(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstInfFloat(Self, isNegative~ : Bool = ..) -> ConstantFP
+fn Context::getConstInfDouble(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstInfFloat(Self, isNegative? : Bool) -> ConstantFP
 fn Context::getConstInt16(Self, Int16) -> ConstantInt
 fn Context::getConstInt16Array(Self, Array[Int16]) -> ConstantArray
 fn Context::getConstInt16Vector(Self, Array[Int16]) -> ConstantVector
@@ -429,12 +436,12 @@ fn Context::getConstInt64Vector(Self, Array[Int64]) -> ConstantVector
 fn Context::getConstInt8(Self, Int) -> ConstantInt
 fn Context::getConstInt8Array(Self, Array[Int]) -> ConstantArray
 fn Context::getConstInt8Vector(Self, Array[Int]) -> ConstantVector
-fn Context::getConstNaNDouble(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstNaNFloat(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstQNaNDouble(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstQNaNFloat(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstSNaNDouble(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstSNaNFloat(Self, isNegative~ : Bool = ..) -> ConstantFP
+fn Context::getConstNaNDouble(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstNaNFloat(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstQNaNDouble(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstQNaNFloat(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstSNaNDouble(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstSNaNFloat(Self, isNegative? : Bool) -> ConstantFP
 fn Context::getConstTrue(Self) -> ConstantInt
 fn Context::getConstUInt16Array(Self, Array[UInt16]) -> ConstantArray
 fn Context::getConstUInt16Vector(Self, Array[UInt16]) -> ConstantVector
@@ -445,8 +452,8 @@ fn Context::getConstUInt64Vector(Self, Array[UInt64]) -> ConstantVector
 fn Context::getConstUInt8Array(Self, Array[Byte]) -> ConstantArray
 fn Context::getConstUInt8Vector(Self, Array[Byte]) -> ConstantVector
 fn Context::getConstZero(Self, &Type) -> &Constant raise LLVMValueError
-fn Context::getConstZeroDouble(Self, isNegative~ : Bool = ..) -> ConstantFP
-fn Context::getConstZeroFloat(Self, isNegative~ : Bool = ..) -> ConstantFP
+fn Context::getConstZeroDouble(Self, isNegative? : Bool) -> ConstantFP
+fn Context::getConstZeroFloat(Self, isNegative? : Bool) -> ConstantFP
 fn Context::getDoubleTy(Self) -> DoubleType
 fn Context::getFP128Ty(Self) -> FP128Type
 fn Context::getFixedVectorType(Self, &Type, UInt) -> FixedVectorType raise LLVMTypeError
@@ -461,9 +468,9 @@ fn Context::getInt8Ty(Self) -> Int8Type
 fn Context::getLabelTy(Self) -> LabelType
 fn Context::getMDString(Self, String) -> MDString
 fn Context::getMetadataTy(Self) -> MetadataType
-fn Context::getPtrTy(Self, addressSpace~ : AddressSpace = ..) -> PointerType
+fn Context::getPtrTy(Self, addressSpace? : AddressSpace) -> PointerType
 fn Context::getScalableVectorType(Self, &Type, UInt) -> ScalableVectorType raise LLVMTypeError
-fn Context::getStructType(Self, Array[&Type], name~ : String = .., isPacked~ : Bool = ..) -> StructType raise LLVMTypeError
+fn Context::getStructType(Self, Array[&Type], name? : String, isPacked? : Bool) -> StructType raise LLVMTypeError
 fn Context::getStructTypeByName(Self, String) -> StructType?
 fn Context::getTokenTy(Self) -> TokenType
 fn Context::getVoidTy(Self) -> VoidType
@@ -657,7 +664,7 @@ pub struct Function {
   // private fields
 }
 fn Function::addAttr(Self, FnAttr) -> Unit
-fn Function::addBasicBlock(Self, name~ : String = .., before~ : BasicBlock? = ..) -> BasicBlock
+fn Function::addBasicBlock(Self, name? : String, before? : BasicBlock?) -> BasicBlock
 fn Function::clearSlot(Self) -> Unit
 fn Function::getArg(Self, Int) -> Argument?
 fn Function::getArgAttrs(Self, UInt) -> @set.Set[ArgAttr]?
@@ -748,84 +755,84 @@ pub struct IRBuilder {
   mut bb : BasicBlock?
   mut insertPt : &Instruction?
 }
-fn IRBuilder::createAShr(Self, &Value, &Value, name~ : String = .., is_exact~ : Bool = ..) -> &Value raise
-fn IRBuilder::createAdd(Self, &Value, &Value, name~ : String = .., has_nsw~ : Bool = .., has_nuw~ : Bool = ..) -> &Value raise
-fn IRBuilder::createAlloca(Self, &Type, addressSpace~ : AddressSpace = .., name~ : String = ..) -> AllocaInst raise
-fn IRBuilder::createAnd(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createBitCast(Self, &Value, &PrimitiveType, name~ : String = ..) -> &Value raise
+fn IRBuilder::createAShr(Self, &Value, &Value, name? : String, is_exact? : Bool) -> &Value raise
+fn IRBuilder::createAdd(Self, &Value, &Value, name? : String, has_nsw? : Bool, has_nuw? : Bool) -> &Value raise
+fn IRBuilder::createAlloca(Self, &Type, addressSpace? : AddressSpace, name? : String) -> AllocaInst raise
+fn IRBuilder::createAnd(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createBitCast(Self, &Value, &PrimitiveType, name? : String) -> &Value raise
 fn IRBuilder::createBr(Self, BasicBlock) -> &Instruction raise
-fn IRBuilder::createCall(Self, Function, Array[&Value], name~ : String = ..) -> CallInst raise
+fn IRBuilder::createCall(Self, Function, Array[&Value], name? : String) -> CallInst raise
 fn IRBuilder::createCondBr(Self, &Value, BasicBlock, BasicBlock) -> &Instruction raise
-fn IRBuilder::createExactSDiv(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createExactUDiv(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createExtractValue(Self, &Value, Array[Int], name~ : String = ..) -> &Value raise
-fn IRBuilder::createFAdd(Self, &Value, &Value, name~ : String = .., fast_math~ : Array[FastMathFlag] = ..) -> &Value raise
-fn IRBuilder::createFCmp(Self, FloatPredicate, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpOEQ(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpOGE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpOGT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpOLE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpOLT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpONE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpORD(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpUEQ(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpUGE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpUGT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpULE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpULT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpUNE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFCmpUNO(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFDiv(Self, &Value, &Value, name~ : String = .., fast_math_flags~ : @set.Set[FastMathFlag] = ..) -> &Value raise
-fn IRBuilder::createFMul(Self, &Value, &Value, name~ : String = .., fast_math_flags~ : @set.Set[FastMathFlag] = ..) -> &Value raise
-fn IRBuilder::createFPExt(Self, &Value, &FPType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFPToSI(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFPToUI(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFPTrunc(Self, &Value, &FPType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createFRem(Self, &Value, &Value, name~ : String = .., fast_math_flags~ : @set.Set[FastMathFlag] = ..) -> &Value raise
-fn IRBuilder::createFSub(Self, &Value, &Value, name~ : String = .., fast_math_flags~ : @set.Set[FastMathFlag] = ..) -> &Value raise
-fn IRBuilder::createGEP(Self, &Value, &Type, Array[&Value], name~ : String = .., inbounds~ : Bool = ..) -> &Value raise
-fn IRBuilder::createICmp(Self, IntPredicate, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpEQ(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpNE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpSGE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpSGT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpSLE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpSLT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpUGE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpUGT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpULE(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createICmpULT(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createInsertValue(Self, &Value, &Value, Array[Int], name~ : String = ..) -> &Value raise
-fn IRBuilder::createIntToPtr(Self, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createLShr(Self, &Value, &Value, name~ : String = .., is_exact~ : Bool = ..) -> &Value raise
-fn IRBuilder::createLoad(Self, &Type, &Value, isVolatile~ : Bool = .., atomicOrdering~ : AtomicOrdering = .., name~ : String = ..) -> &Value raise
-fn IRBuilder::createMul(Self, &Value, &Value, name~ : String = .., has_nsw~ : Bool = .., has_nuw~ : Bool = ..) -> &Value raise
-fn IRBuilder::createNSWAdd(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createNSWMul(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createNSWSub(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createNUWAdd(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createNUWMul(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createNUWSub(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createOr(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createPHI(Self, &Type, name~ : String = ..) -> PHINode raise
-fn IRBuilder::createPtrToInt(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
+fn IRBuilder::createExactSDiv(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createExactUDiv(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createExtractValue(Self, &Value, Array[Int], name? : String) -> &Value raise
+fn IRBuilder::createFAdd(Self, &Value, &Value, name? : String, fast_math? : Array[FastMathFlag]) -> &Value raise
+fn IRBuilder::createFCmp(Self, FloatPredicate, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpOEQ(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpOGE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpOGT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpOLE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpOLT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpONE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpORD(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpUEQ(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpUGE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpUGT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpULE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpULT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpUNE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFCmpUNO(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createFDiv(Self, &Value, &Value, name? : String, fast_math_flags? : @set.Set[FastMathFlag]) -> &Value raise
+fn IRBuilder::createFMul(Self, &Value, &Value, name? : String, fast_math_flags? : @set.Set[FastMathFlag]) -> &Value raise
+fn IRBuilder::createFPExt(Self, &Value, &FPType, name? : String) -> &Value raise
+fn IRBuilder::createFPToSI(Self, &Value, &IntegerType, name? : String) -> &Value raise
+fn IRBuilder::createFPToUI(Self, &Value, &IntegerType, name? : String) -> &Value raise
+fn IRBuilder::createFPTrunc(Self, &Value, &FPType, name? : String) -> &Value raise
+fn IRBuilder::createFRem(Self, &Value, &Value, name? : String, fast_math_flags? : @set.Set[FastMathFlag]) -> &Value raise
+fn IRBuilder::createFSub(Self, &Value, &Value, name? : String, fast_math_flags? : @set.Set[FastMathFlag]) -> &Value raise
+fn IRBuilder::createGEP(Self, &Value, &Type, Array[&Value], name? : String, inbounds? : Bool) -> &Value raise
+fn IRBuilder::createICmp(Self, IntPredicate, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpEQ(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpNE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpSGE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpSGT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpSLE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpSLT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpUGE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpUGT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpULE(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createICmpULT(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createInsertValue(Self, &Value, &Value, Array[Int], name? : String) -> &Value raise
+fn IRBuilder::createIntToPtr(Self, &Value, name? : String) -> &Value raise
+fn IRBuilder::createLShr(Self, &Value, &Value, name? : String, is_exact? : Bool) -> &Value raise
+fn IRBuilder::createLoad(Self, &Type, &Value, isVolatile? : Bool, atomicOrdering? : AtomicOrdering, name? : String) -> &Value raise
+fn IRBuilder::createMul(Self, &Value, &Value, name? : String, has_nsw? : Bool, has_nuw? : Bool) -> &Value raise
+fn IRBuilder::createNSWAdd(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createNSWMul(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createNSWSub(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createNUWAdd(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createNUWMul(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createNUWSub(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createOr(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createPHI(Self, &Type, name? : String) -> PHINode raise
+fn IRBuilder::createPtrToInt(Self, &Value, &IntegerType, name? : String) -> &Value raise
 fn IRBuilder::createRet(Self, &Value) -> &Instruction raise
 fn IRBuilder::createRetVoid(Self) -> &Instruction raise
-fn IRBuilder::createSDiv(Self, &Value, &Value, name~ : String = .., is_exact~ : Bool = ..) -> &Value raise
-fn IRBuilder::createSExt(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createSIToFP(Self, &Value, &FPType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createSRem(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createSelect(Self, &Value, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createShl(Self, &Value, &Value, name~ : String = .., has_nsw~ : Bool = .., has_nuw~ : Bool = ..) -> &Value raise
-fn IRBuilder::createStore(Self, &Value, &Value, isVolatile~ : Bool = .., atomicOrdering~ : AtomicOrdering = ..) -> &Instruction raise
-fn IRBuilder::createSub(Self, &Value, &Value, name~ : String = .., has_nsw~ : Bool = .., has_nuw~ : Bool = ..) -> &Value raise
+fn IRBuilder::createSDiv(Self, &Value, &Value, name? : String, is_exact? : Bool) -> &Value raise
+fn IRBuilder::createSExt(Self, &Value, &IntegerType, name? : String) -> &Value raise
+fn IRBuilder::createSIToFP(Self, &Value, &FPType, name? : String) -> &Value raise
+fn IRBuilder::createSRem(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createSelect(Self, &Value, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createShl(Self, &Value, &Value, name? : String, has_nsw? : Bool, has_nuw? : Bool) -> &Value raise
+fn IRBuilder::createStore(Self, &Value, &Value, isVolatile? : Bool, atomicOrdering? : AtomicOrdering) -> &Instruction raise
+fn IRBuilder::createSub(Self, &Value, &Value, name? : String, has_nsw? : Bool, has_nuw? : Bool) -> &Value raise
 fn IRBuilder::createSwitch(Self, &Value, BasicBlock) -> SwitchInst raise
-fn IRBuilder::createTrunc(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createUDiv(Self, &Value, &Value, name~ : String = .., is_exact~ : Bool = ..) -> &Value raise
-fn IRBuilder::createUIToFP(Self, &Value, &FPType, name~ : String = ..) -> &Value raise
-fn IRBuilder::createURem(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createXor(Self, &Value, &Value, name~ : String = ..) -> &Value raise
-fn IRBuilder::createZExt(Self, &Value, &IntegerType, name~ : String = ..) -> &Value raise
+fn IRBuilder::createTrunc(Self, &Value, &IntegerType, name? : String) -> &Value raise
+fn IRBuilder::createUDiv(Self, &Value, &Value, name? : String, is_exact? : Bool) -> &Value raise
+fn IRBuilder::createUIToFP(Self, &Value, &FPType, name? : String) -> &Value raise
+fn IRBuilder::createURem(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createXor(Self, &Value, &Value, name? : String) -> &Value raise
+fn IRBuilder::createZExt(Self, &Value, &IntegerType, name? : String) -> &Value raise
 fn IRBuilder::getInsertBlock(Self) -> BasicBlock
 fn IRBuilder::getInsertFunction(Self) -> Function
 fn[T : InsertPoint] IRBuilder::setInsertPoint(Self, T) -> Unit
@@ -852,7 +859,7 @@ impl Show for InsertValueInst
 pub struct InstBase {
   // private fields
 }
-fn InstBase::new(bb~ : BasicBlock? = .., next~ : &Instruction? = .., prev~ : &Instruction? = ..) -> Self
+fn InstBase::new(bb? : BasicBlock?, next? : &Instruction?, prev? : &Instruction?) -> Self
 
 pub enum InstEnum {
   AllocaInst(AllocaInst)
@@ -988,12 +995,6 @@ impl Show for IntegerTypeEnum
 
 type LLVMContextImpl
 
-type LLVMTypeError
-impl Show for LLVMTypeError
-
-pub suberror LLVMValueError String
-impl Show for LLVMValueError
-
 pub struct LabelType {
   // private fields
 }
@@ -1069,7 +1070,7 @@ pub struct Module {
   moduleID : String
   dataLayout : DataLayout
 }
-fn Module::addFunction(Self, FunctionType, String, linkage~ : LinkageTypes = .., addressSpace~ : AddressSpace = ..) -> Function raise LLVMValueError
+fn Module::addFunction(Self, FunctionType, String, linkage? : LinkageTypes, addressSpace? : AddressSpace) -> Function raise LLVMValueError
 fn Module::dump(Self) -> Unit
 fn Module::getContext(Self) -> Context
 fn Module::new(String, String, Context) -> Self
@@ -1222,7 +1223,7 @@ fn StructType::isOpaque(Self) -> Bool
 fn StructType::isPacked(Self) -> Bool
 fn StructType::isSized(Self) -> Bool
 fn StructType::removeName(Self) -> Unit
-fn StructType::setBody(Self, Array[&Type], isPacked~ : Bool = ..) -> Unit raise LLVMTypeError
+fn StructType::setBody(Self, Array[&Type], isPacked? : Bool) -> Unit raise LLVMTypeError
 fn StructType::setName(Self, String) -> Unit raise LLVMTypeError
 impl AggregateType for StructType
 impl Type for StructType

--- a/IR/Instruction.mbt
+++ b/IR/Instruction.mbt
@@ -41,7 +41,7 @@ fn AllocaInst::new(
   data_ty : &Type,
   parent : Function,
   addressSpace~ : AddressSpace,
-  name~ : String? = None,
+  name~ : String?,
 ) -> AllocaInst {
   let uid = valueUIDAssigner.assign()
   let vty = data_ty.getContext().getPtrTy(addressSpace~)
@@ -305,7 +305,7 @@ fn LoadInst::new(
   isVolatile : Bool,
   atomicOrdering : AtomicOrdering,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> LoadInst {
   let vty = load_ty
   let inst_base = InstBase::new()
@@ -876,7 +876,7 @@ fn BinaryInst::newStandardOp(
   lhs : &Value,
   rhs : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
   flags : Set[BinaryOpFlags],
 ) -> BinaryInst {
   guard opcode
@@ -927,7 +927,7 @@ fn BinaryInst::newFPMathOp(
   lhs : &Value,
   rhs : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
   fast_math_flags : Set[FastMathFlag],
 ) -> BinaryInst {
   guard opcode is (FAdd | FSub | FMul | FDiv | FRem) else {
@@ -1246,7 +1246,7 @@ fn ICmpInst::new(
   lhs : &Value,
   rhs : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> ICmpInst {
   let (lhsTy, rhsTy) = (lhs.getType(), rhs.getType())
   guard lhsTy == rhsTy
@@ -1569,7 +1569,7 @@ fn FCmpInst::new(
   lhs : &Value,
   rhs : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> FCmpInst {
   let (lhsTy, rhsTy) = (lhs.getType(), rhs.getType())
   guard lhsTy == rhsTy
@@ -1862,7 +1862,7 @@ fn CastInst::newTrunc(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   guard from_val.getType().tryAsIntTypeEnum() is Some(from_ty)
   guard from_ty.getBitWidth() > to_ty.getBitWidth()
@@ -1887,7 +1887,7 @@ fn CastInst::newZExt(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   guard from_val.getType().tryAsIntTypeEnum() is Some(from_ty)
   guard from_ty.getBitWidth() < to_ty.getBitWidth()
@@ -1912,7 +1912,7 @@ fn CastInst::newSExt(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -1935,7 +1935,7 @@ fn CastInst::newFPTrunc(
   from_val : &Value,
   to_ty : &FPType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -1958,7 +1958,7 @@ fn CastInst::newFPExt(
   from_val : &Value,
   to_ty : &FPType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -1981,7 +1981,7 @@ fn CastInst::newUIToFP(
   from_val : &Value,
   to_ty : &FPType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2004,7 +2004,7 @@ fn CastInst::newFPToUI(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2027,7 +2027,7 @@ fn CastInst::newSIToFP(
   from_val : &Value,
   to_ty : &FPType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2050,7 +2050,7 @@ fn CastInst::newFPToSI(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2073,7 +2073,7 @@ fn CastInst::newPtrToInt(
   from_val : &Value,
   to_ty : &IntegerType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2095,7 +2095,7 @@ fn CastInst::newPtrToInt(
 fn CastInst::newIntToPtr(
   from_val : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let to_ty = from_val.getContext().getPtrTy()
   let uid = valueUIDAssigner.assign()
@@ -2121,7 +2121,7 @@ fn CastInst::newBitCast(
   from_val : &Value,
   to_ty : &PrimitiveType,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CastInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2376,7 +2376,7 @@ fn GetElementPtrInst::new(
   indices : Array[&Value],
   isInbounds : Bool,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> GetElementPtrInst {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
@@ -2644,7 +2644,7 @@ fn SelectInst::new(
   trueValue : &Value,
   falseValue : &Value,
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> SelectInst {
   let vty = trueValue.getType()
   let uid = valueUIDAssigner.assign()
@@ -3509,11 +3509,7 @@ pub struct PHINode {
 }
 
 ///|
-fn PHINode::new(
-  vty : &Type,
-  parent : Function,
-  name~ : String? = None,
-) -> PHINode {
+fn PHINode::new(vty : &Type, parent : Function, name~ : String?) -> PHINode {
   let uid = valueUIDAssigner.assign()
   let inst_base = InstBase::new()
   PHINode::{ uid, vty, users: [], name, incomings: [], parent, inst_base }
@@ -3834,7 +3830,7 @@ fn CallInst::new(
   callee : Function,
   args : Array[&Value],
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> CallInst {
   let fty = callee.getFunctionType()
   let name = match fty.getReturnType().asTypeEnum() {
@@ -4172,7 +4168,7 @@ fn ExtractValueInst::new(
   aggregate : &Value,
   indices : Array[Int],
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> ExtractValueInst {
   let agg_ty = aggregate.getType()
   guard agg_ty.tryAsAggregateTypeEnum() is Some(agg_ty)
@@ -4434,7 +4430,7 @@ fn InsertValueInst::new(
   insert_val : &Value,
   indices : Array[Int],
   parent : Function,
-  name~ : String? = None,
+  name~ : String?,
 ) -> InsertValueInst {
   let agg_ty = aggregate.getType()
   guard agg_ty.tryAsAggregateTypeEnum() is Some(agg_ty)

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -2064,7 +2064,7 @@ pub impl AggregateType for ScalableVectorType with asAggregateTypeEnum(self) -> 
 // ====================================================================
 
 ///| Memory address space of a pointer type.
-pub type AddressSpace UInt derive(Hash, Show, Eq, Default)
+pub struct AddressSpace(UInt) derive(Hash, Show, Eq, Default)
 
 ///|
 pub fn AddressSpace::new(v : UInt) -> AddressSpace {

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -1576,8 +1576,8 @@ pub struct StructType {
 fn StructType::new(
   context : Context,
   elements : Array[&Type],
-  name~ : String? = None,
-  isPacked~ : Bool = false,
+  name~ : String?,
+  isPacked~ : Bool,
 ) -> StructType raise LLVMTypeError {
   if name is None && elements.is_empty() {
     raise OpaqueStructMustHaveName
@@ -2101,7 +2101,7 @@ pub struct PointerType {
 ///|
 fn PointerType::new(
   context : Context,
-  addressSpace~ : AddressSpace = AddressSpace::default(),
+  addressSpace~ : AddressSpace,
 ) -> PointerType {
   let base = TypeBase::new(context)
   PointerType::{ base, addressSpace }

--- a/IR/lib.mbt
+++ b/IR/lib.mbt
@@ -27,34 +27,34 @@ fn ValueUIDAssigner::assign(self : ValueUIDAssigner) -> UInt64 {
 // ====================================================
 
 ///|
-type Int8Array Array[Int8] derive(Eq, Hash, Show)
+struct Int8Array(Array[Int8]) derive(Eq, Hash, Show)
 
 ///|
-type Int16Array Array[Int16] derive(Eq, Hash, Show)
+struct Int16Array(Array[Int16]) derive(Eq, Hash, Show)
 
 ///|
-type Int32Array Array[Int] derive(Eq, Hash, Show)
+struct Int32Array(Array[Int]) derive(Eq, Hash, Show)
 
 ///|
-type Int64Array Array[Int64] derive(Eq, Hash, Show)
+struct Int64Array(Array[Int64]) derive(Eq, Hash, Show)
 
 ///|
-type UInt8Array Array[UInt8] derive(Eq, Hash, Show)
+struct UInt8Array(Array[UInt8]) derive(Eq, Hash, Show)
 
 ///|
-type UInt16Array Array[UInt16] derive(Eq, Hash, Show)
+struct UInt16Array(Array[UInt16]) derive(Eq, Hash, Show)
 
 ///|
-type UInt32Array Array[UInt] derive(Eq, Hash, Show)
+struct UInt32Array(Array[UInt]) derive(Eq, Hash, Show)
 
 ///|
-type UInt64Array Array[UInt64] derive(Eq, Hash, Show)
+struct UInt64Array(Array[UInt64]) derive(Eq, Hash, Show)
 
 ///|
-type FloatArray Array[Float] derive(Eq, Hash, Show)
+struct FloatArray(Array[Float]) derive(Eq, Hash, Show)
 
 ///|
-type DoubleArray Array[Double] derive(Eq, Hash, Show)
+struct DoubleArray(Array[Double]) derive(Eq, Hash, Show)
 
 ///|
 pub fn Int8Array::from(data : Array[Int8]) -> Int8Array {

--- a/Support/Support.mbti
+++ b/Support/Support.mbti
@@ -3,6 +3,8 @@ package "Kaida-Amethyst/MoonLLVM/Support"
 
 // Values
 
+// Errors
+
 // Types and methods
 
 // Type aliases

--- a/doc/doc.mbti
+++ b/doc/doc.mbti
@@ -3,6 +3,8 @@ package "Kaida-Amethyst/MoonLLVM/doc"
 
 // Values
 
+// Errors
+
 // Types and methods
 
 // Type aliases

--- a/int8/int8.mbti
+++ b/int8/int8.mbti
@@ -6,8 +6,10 @@ let max_value : Int8
 
 let min_value : Int8
 
+// Errors
+
 // Types and methods
-pub type Int8 Int
+pub struct Int8(Int)
 fn Int8::from(Int) -> Self
 fn Int8::from_int64(Int64) -> Self
 fn Int8::from_uint64(UInt64) -> Self

--- a/int8/lib.mbt
+++ b/int8/lib.mbt
@@ -1,5 +1,5 @@
 ///|
-pub type Int8 Int derive(Eq, Hash, Compare)
+pub struct Int8(Int) derive(Eq, Hash, Compare)
 
 ///|
 pub let max_value : Int8 = 127

--- a/main/main.mbti
+++ b/main/main.mbti
@@ -3,6 +3,8 @@ package "Kaida-Amethyst/MoonLLVM/main"
 
 // Values
 
+// Errors
+
 // Types and methods
 
 // Type aliases

--- a/test/test.mbti
+++ b/test/test.mbti
@@ -3,6 +3,8 @@ package "Kaida-Amethyst/MoonLLVM/test"
 
 // Values
 
+// Errors
+
 // Types and methods
 
 // Type aliases

--- a/uint8/lib.mbt
+++ b/uint8/lib.mbt
@@ -1,5 +1,5 @@
 ///|
-pub type UInt8 Byte derive(Eq, Hash, Compare)
+pub struct UInt8(Byte) derive(Eq, Hash, Compare)
 
 ///|
 pub let max_value : UInt8 = 255

--- a/uint8/uint8.mbti
+++ b/uint8/uint8.mbti
@@ -6,8 +6,10 @@ let max_value : UInt8
 
 let min_value : UInt8
 
+// Errors
+
 // Types and methods
-pub type UInt8 Byte
+pub struct UInt8(Byte)
 fn UInt8::from(Byte) -> Self
 fn UInt8::from_int64(Int64) -> Self
 fn UInt8::from_uint64(UInt64) -> Self


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all compiler warnings [0032] by removing unused default value assignments for optional parameters. The warnings were caused by optional parameters that had default values that were never used in practice.

Changes made:
- IR/BasicBlock.mbt: Removed `= None` from `name~` parameter in `BasicBlock::new`
- IR/Instruction.mbt: Removed `= None` from multiple `name~` parameters in various instruction constructors
- IR/Type.mbt: Removed unused default values from `StructType::new` and `PointerType::new`

All tests pass and the project builds successfully without any compiler warnings.