### PR TITLE
Update documentation to reflect changes in command syntax and examples

### DIFF
--- a/IR/BasicBlock.mbt
+++ b/IR/BasicBlock.mbt
@@ -56,24 +56,17 @@ fn BasicBlock::new(parent : Function, name~ : String?) -> BasicBlock {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let fval = mod.addFunction(fty, "ret_42")
-///
 /// let arg0 = fval.getArg(0).unwrap()
 /// let arg1 = fval.getArg(1).unwrap()
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let sum1 = builder.createAdd(arg0, arg1, name="sum1")
 /// let sum2 = builder.createAdd(arg0, arg1, name="sum2")
 /// let mul = builder.createMul(sum1, sum2, name="mul")
-///
 /// let _ = builder.createRet(mul)
-///
 /// inspect(bb.firstInst().unwrap(), content="  %sum1 = add i32 %0, %1")
 /// ```
 pub fn BasicBlock::firstInst(self : BasicBlock) -> &Instruction? {
@@ -87,24 +80,17 @@ pub fn BasicBlock::firstInst(self : BasicBlock) -> &Instruction? {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let fval = mod.addFunction(fty, "ret_42")
-///
 /// let arg0 = fval.getArg(0).unwrap()
 /// let arg1 = fval.getArg(1).unwrap()
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let sum1 = builder.createAdd(arg0, arg1, name="sum1")
 /// let sum2 = builder.createAdd(arg0, arg1, name="sum2")
 /// let mul = builder.createMul(sum1, sum2, name="mul")
-///
 /// let _ = builder.createRet(mul)
-///
 /// inspect(bb.lastInst().unwrap(), content="  ret i32 %mul")
 /// ```
 pub fn BasicBlock::lastInst(self : BasicBlock) -> &Instruction? {

--- a/IR/BasicBlock.mbt
+++ b/IR/BasicBlock.mbt
@@ -52,7 +52,7 @@ fn BasicBlock::new(parent : Function, name~ : String?) -> BasicBlock {
 ///|
 /// Get the first instruction in the basic block.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -83,7 +83,7 @@ pub fn BasicBlock::firstInst(self : BasicBlock) -> &Instruction? {
 ///|
 /// Get the last instruction in the basic block.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()

--- a/IR/Constants.mbt
+++ b/IR/Constants.mbt
@@ -8,7 +8,7 @@
 /// Use `Context::getConstInt8, getConstInt16, getConstInt32, getConstInt64`
 /// To create a new ConstantInt.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i8 = ctx.getConstInt8(0)
 /// let i16 = ctx.getConstInt16(1)
@@ -52,7 +52,7 @@ fn ConstantInt::getValue(self : ConstantInt) -> Int64 {
 ///|
 /// Get the value of this constant as a signed 64-bits integer.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_zero = ctx.getConstInt8(0)
@@ -74,7 +74,7 @@ pub fn ConstantInt::getValueAsInt64(self : ConstantInt) -> Int64 {
 ///|
 /// Get the type of constant int value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_zero = ctx.getConstInt8(0)
@@ -94,7 +94,7 @@ pub fn ConstantInt::getIntegerType(self : ConstantInt) -> &IntegerType {
 ///|
 /// Compare the value of this constant int with a signed integer.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// assert_true(ctx.getConstInt8(0).equals(0))
@@ -145,7 +145,7 @@ pub fn ConstantInt::isMinValue(self : ConstantInt) -> Bool {
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_0 = ctx.getConstInt8(0)
@@ -193,7 +193,7 @@ pub fn ConstantInt::add(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_0 = ctx.getConstInt8(0)
@@ -242,7 +242,7 @@ pub fn ConstantInt::sub(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_0 = ctx.getConstInt8(0)
@@ -288,7 +288,7 @@ pub fn ConstantInt::mul(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_1 = ctx.getConstInt8(1)
@@ -338,7 +338,7 @@ pub fn ConstantInt::sdiv(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same. It will raise `DivisionByZeroError` if `other` is zero.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test case 1: i8 unsigned division
@@ -423,7 +423,7 @@ pub fn ConstantInt::udiv(
 ///|
 /// Bitwise AND two ConstantInt, useful in constant folding.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_6 = ctx.getConstInt8(6)     // 00000110
@@ -469,7 +469,7 @@ pub fn ConstantInt::compute_and(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_6 = ctx.getConstInt8(6)     // 00000110
@@ -515,7 +515,7 @@ pub fn ConstantInt::or(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_6 = ctx.getConstInt8(6)     // 00000110
@@ -561,7 +561,7 @@ pub fn ConstantInt::xor(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_1 = ctx.getConstInt8(1)     // 00000001
@@ -607,7 +607,7 @@ pub fn ConstantInt::compute_shl(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_200 = ctx.getConstInt8(200)  // 11001000 (as unsigned)
@@ -671,7 +671,7 @@ pub fn ConstantInt::lshr(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_m1 = ctx.getConstInt8(-1)   // 11111111
@@ -722,7 +722,7 @@ pub fn ConstantInt::ashr(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantInt are not the same. Only ICMP_xxx predicates are supported.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_5 = ctx.getConstInt8(5)
@@ -843,7 +843,7 @@ pub fn ConstantInt::compare(
 /// **Note**: It will raise `TruncCastInstTypeMismatch` if the source type bit width
 /// is not greater than the destination type bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i32_255 = ctx.getConstInt32(255)
@@ -880,7 +880,7 @@ pub fn ConstantInt::trunc(
 /// **Note**: It will raise `ZExtCastInstTypeMismatch` if the source type bit width
 /// is not less than the destination type bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_255 = ctx.getConstInt8(255) // -1 as signed, 255 as unsigned
@@ -925,7 +925,7 @@ pub fn ConstantInt::zext(
 /// **Note**: It will raise `SExtCastInstTypeMismatch` if the source type bit width
 /// is not less than the destination type bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8_m1 = ctx.getConstInt8(-1)
@@ -966,7 +966,7 @@ pub fn ConstantInt::sext(
 ///
 /// **Note**: It will raise `UIToFPInstTypeMismatch` if the source is not an integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i32_255 = ctx.getConstInt32(255)
@@ -1000,7 +1000,7 @@ pub fn ConstantInt::uitofp(self : ConstantInt, dst_ty : &FPType) -> ConstantFP {
 ///
 /// **Note**: It will raise `SIToFPInstTypeMismatch` if the source is not an integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i32_m42 = ctx.getConstInt32(-42)
@@ -1028,7 +1028,7 @@ pub fn ConstantInt::sitofp(self : ConstantInt, dst_ty : &FPType) -> ConstantFP {
 /// For constant folding, this always returns a null pointer since we cannot create
 /// meaningful pointer constants from integer values at compile time.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i64_0 = ctx.getConstInt64(0)
@@ -1051,7 +1051,7 @@ pub fn ConstantInt::inttoptr(self : ConstantInt) -> ConstantPointerNull {
 /// or if the cast is invalid. It will raise `BitCastOnlyAcceptPrimitiveTypes` if the source
 /// is not a primitive type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test i32 to f32 bitcast
@@ -1217,7 +1217,7 @@ pub fn[T : Floating] ConstantFP::exactlyEquals(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantFP are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32_0 = ctx.getConstFloat(0.0)
@@ -1250,7 +1250,7 @@ pub fn ConstantFP::add(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantFP are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32_0 = ctx.getConstFloat(0.0)
@@ -1283,7 +1283,7 @@ pub fn ConstantFP::sub(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantFP are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32_0 = ctx.getConstFloat(0.0)
@@ -1316,7 +1316,7 @@ pub fn ConstantFP::mul(
 /// **Note**: It will raise `TypeMismatchForBinaryOp` if the types of two
 /// ConstantFP are not the same.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32_0 = ctx.getConstFloat(0.0)
@@ -1349,7 +1349,7 @@ pub fn ConstantFP::div(
 /// **Note**: It will raise `TypeMismatchForCmpInst` if the types of two
 /// ConstantFP are not the same. Only FCMP_xxx predicates are supported.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32_1_5 = ctx.getConstFloat(1.5)
@@ -1440,7 +1440,7 @@ pub fn ConstantFP::compare(
 /// **Note**: It will raise `FPTruncCastInstTypeMismatch` if the source type bit width
 /// is not greater than the destination type bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test f64 to f32 truncation
@@ -1478,7 +1478,7 @@ pub fn ConstantFP::fptrunc(
 /// **Note**: It will raise `FPExtCastInstTypeMismatch` if the source type bit width
 /// is not less than the destination type bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test f32 to f64 extension
@@ -1514,7 +1514,7 @@ pub fn ConstantFP::fpext(
 /// **Note**: It will raise `FPToUIInstTypeMismatch` if the source is not a floating-point type.
 /// The conversion truncates towards zero (similar to C cast).
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test positive float to unsigned integer
@@ -1557,7 +1557,7 @@ pub fn ConstantFP::fptoui(
 /// **Note**: It will raise `FPToSIInstTypeMismatch` if the source is not a floating-point type.
 /// The conversion truncates towards zero (similar to C cast).
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test positive float to signed integer
@@ -1596,7 +1596,7 @@ pub fn ConstantFP::fptosi(
 /// or if the cast is invalid. It will raise `BitCastOnlyAcceptPrimitiveTypes` if the source
 /// is not a primitive type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// // Test f32 to i32 bitcast
@@ -2533,7 +2533,7 @@ pub impl Show for ConstantVector with output(self, logger) {
 ///
 /// Represents a constant struct value in LLVM IR.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -2602,7 +2602,7 @@ pub fn ConstantStruct::getElement(
 /// This is equivalent to LLVM's `extractvalue` instruction for constant structs.
 /// The indices specify a path through nested aggregate types.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -2644,7 +2644,7 @@ pub fn ConstantStruct::extractValue(
 /// This is equivalent to LLVM's `insertvalue` instruction for constant structs.
 /// Returns a new ConstantStruct with the value inserted at the specified path.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()

--- a/IR/Constants.mbt
+++ b/IR/Constants.mbt
@@ -14,7 +14,6 @@
 /// let i16 = ctx.getConstInt16(1)
 /// let i32 = ctx.getConstInt32(-2)
 /// let i64 = ctx.getConstInt64(16)
-///
 /// inspect(i8, content="i8 0")
 /// inspect(i16, content="i16 1")
 /// inspect(i32, content="i32 -2")
@@ -54,13 +53,11 @@ fn ConstantInt::getValue(self : ConstantInt) -> Int64 {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_zero = ctx.getConstInt8(0)
 /// let i16_one = ctx.getConstInt16(1)
 /// let i32_two = ctx.getConstInt32(2)
 /// let i64_m1 = ctx.getConstInt64(-1)
 /// let i8_m1 = ctx.getConstInt8(-1)
-///
 /// assert_eq(i8_zero.getValueAsInt64(), 0)
 /// assert_eq(i16_one.getValueAsInt64(), 1)
 /// assert_eq(i32_two.getValueAsInt64(), 2)
@@ -76,12 +73,10 @@ pub fn ConstantInt::getValueAsInt64(self : ConstantInt) -> Int64 {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_zero = ctx.getConstInt8(0)
 /// let i16_one = ctx.getConstInt16(1)
 /// let i32_m2 = ctx.getConstInt32(-2)
 /// let i64_m16 = ctx.getConstInt64(-16)
-///
 /// inspect(i8_zero.getIntegerType(), content="i8")
 /// inspect(i16_one.getIntegerType(), content="i16")
 /// inspect(i32_m2.getIntegerType(), content="i32")
@@ -96,7 +91,6 @@ pub fn ConstantInt::getIntegerType(self : ConstantInt) -> &IntegerType {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// assert_true(ctx.getConstInt8(0).equals(0))
 /// assert_true(ctx.getConstInt8(-1).equals(-1))
 /// assert_true(ctx.getConstInt8(1).equals(1))
@@ -147,24 +141,19 @@ pub fn ConstantInt::isMinValue(self : ConstantInt) -> Bool {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_0 = ctx.getConstInt8(0)
 /// let i8_31 = ctx.getConstInt8(31)
 /// inspect(i8_0.add(i8_31), content="i8 31")
-///
 /// let i16_5 = ctx.getConstInt16(5)
 /// let i16_72 = ctx.getConstInt16(72)
 /// inspect(i16_5.add(i16_72), content="i16 77")
-///
 /// let i32_m7 = ctx.getConstInt32(-7)
 /// let i32_81 = ctx.getConstInt32(81)
 /// inspect(i32_m7.add(i32_81), content="i32 74")
-///
 /// let i64_16 = ctx.getConstInt64(16)
 /// let i64_m33 = ctx.getConstInt64(-33)
 /// inspect(i64_16.add(i64_m33), content="i64 -17")
-///
-/// assert_true({try? i8_0.add(i16_5)} is Err(_))
+/// assert_true((try? i8_0.add(i16_5)) is Err(_))
 /// ```
 pub fn ConstantInt::add(
   self : ConstantInt,
@@ -195,25 +184,20 @@ pub fn ConstantInt::add(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_0 = ctx.getConstInt8(0)
 /// let i8_31 = ctx.getConstInt8(31)
 /// inspect(i8_31.sub(i8_0), content="i8 31")
 /// inspect(i8_0.sub(i8_31), content="i8 -31")
-///
 /// let i16_5 = ctx.getConstInt16(5)
 /// let i16_72 = ctx.getConstInt16(72)
 /// inspect(i16_72.sub(i16_5), content="i16 67")
-///
 /// let i32_m7 = ctx.getConstInt32(-7)
 /// let i32_81 = ctx.getConstInt32(81)
 /// inspect(i32_m7.sub(i32_81), content="i32 -88")
-///
 /// let i64_16 = ctx.getConstInt64(16)
 /// let i64_m33 = ctx.getConstInt64(-33)
 /// inspect(i64_16.sub(i64_m33), content="i64 49")
-///
-/// assert_true({try? i32_81.sub(i64_16)} is Err(_))
+/// assert_true((try? i32_81.sub(i64_16)) is Err(_))
 /// ```
 pub fn ConstantInt::sub(
   self : ConstantInt,
@@ -244,19 +228,15 @@ pub fn ConstantInt::sub(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_0 = ctx.getConstInt8(0)
 /// let i8_31 = ctx.getConstInt8(31)
 /// inspect(i8_0.mul(i8_31), content="i8 0")
-///
 /// let i16_5 = ctx.getConstInt16(5)
 /// let i16_72 = ctx.getConstInt16(72)
 /// inspect(i16_5.mul(i16_72), content="i16 360")
-///
 /// let i32_m7 = ctx.getConstInt32(-7)
 /// let i32_81 = ctx.getConstInt32(81)
 /// inspect(i32_m7.mul(i32_81), content="i32 -567")
-///
 /// let i64_16 = ctx.getConstInt64(16)
 /// let i64_m33 = ctx.getConstInt64(-33)
 /// inspect(i64_16.mul(i64_m33), content="i64 -528")
@@ -290,19 +270,15 @@ pub fn ConstantInt::mul(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_1 = ctx.getConstInt8(1)
 /// let i8_31 = ctx.getConstInt8(31)
 /// inspect(i8_31.sdiv(i8_1), content="i8 31")
-///
 /// let i16_5 = ctx.getConstInt16(5)
 /// let i16_72 = ctx.getConstInt16(72)
 /// inspect(i16_72.sdiv(i16_5), content="i16 14")
-///
 /// let i32_m7 = ctx.getConstInt32(-7)
 /// let i32_81 = ctx.getConstInt32(81)
 /// inspect(i32_m7.sdiv(i32_81), content="i32 0")
-///
 /// let i64_16 = ctx.getConstInt64(16)
 /// let i64_m33 = ctx.getConstInt64(-33)
 /// inspect(i64_16.sdiv(i64_m33), content="i64 0")
@@ -368,11 +344,11 @@ pub fn ConstantInt::sdiv(
 /// // Test case 5: Type mismatch
 /// let i8_5 = ctx.getConstInt8(5)
 /// let i16_2 = ctx.getConstInt16(2)
-/// assert_true({try? i8_5.udiv(i16_2)} is Err(_))
+/// assert_true((try? i8_5.udiv(i16_2)) is Err(_))
 ///
 /// // Test case 6: Division by zero
 /// let i8_0 = ctx.getConstInt8(0)
-/// assert_true({try? i8_5.udiv(i8_0)} is Err(_))
+/// assert_true((try? i8_5.udiv(i8_0)) is Err(_))
 ///
 /// // Test case 7: i1 unsigned division
 /// let i1_true = ctx.getConstTrue()
@@ -425,21 +401,17 @@ pub fn ConstantInt::udiv(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_6 = ctx.getConstInt8(6)     // 00000110
-/// let i8_3 = ctx.getConstInt8(3)     // 00000011
+/// let i8_6 = ctx.getConstInt8(6) // 00000110
+/// let i8_3 = ctx.getConstInt8(3) // 00000011
 /// inspect(i8_6.compute_and(i8_3), content="i8 2") // 00000010
-///
 /// let i16_m1 = ctx.getConstInt16(-1) // 1111111111111111
 /// let i16_all_set = ctx.getConstInt16(-1)
 /// inspect(i16_m1.compute_and(i16_all_set), content="i16 -1")
-///
 /// let i32_pattern = ctx.getConstInt32(0x0F0F0F0F)
 /// let i32_mask = ctx.getConstInt32(0xFF00FF00)
 /// inspect(i32_pattern.compute_and(i32_mask), content="i32 251662080") // 0x0F000F00
-///
 /// let i64_val = ctx.getConstInt64(0x123456789ABCDEF0L)
-/// let i64_low_clear = ctx.getConstInt64(-1L<<4) // ...FFFFFFFFFFFFFFF0
+/// let i64_low_clear = ctx.getConstInt64(-1L << 4) // ...FFFFFFFFFFFFFFF0
 /// inspect(i64_val.compute_and(i64_low_clear), content="i64 1311768467463790320") // 0x123456789ABCDEF0
 /// ```
 pub fn ConstantInt::compute_and(
@@ -471,19 +443,15 @@ pub fn ConstantInt::compute_and(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_6 = ctx.getConstInt8(6)     // 00000110
-/// let i8_3 = ctx.getConstInt8(3)     // 00000011
-/// inspect(i8_6.or(i8_3), content="i8 7")  // 00000111
-///
-/// let i16_1 = ctx.getConstInt16(1)   // ...0001
-/// let i16_2 = ctx.getConstInt16(2)   // ...0010
+/// let i8_6 = ctx.getConstInt8(6) // 00000110
+/// let i8_3 = ctx.getConstInt8(3) // 00000011
+/// inspect(i8_6.or(i8_3), content="i8 7") // 00000111
+/// let i16_1 = ctx.getConstInt16(1) // ...0001
+/// let i16_2 = ctx.getConstInt16(2) // ...0010
 /// inspect(i16_1.or(i16_2), content="i16 3") // ...0011
-///
 /// let i32_pattern = ctx.getConstInt32(0x0F0F0F0F)
 /// let i32_mask = ctx.getConstInt32(0xF0F0F0F0)
 /// inspect(i32_pattern.or(i32_mask), content="i32 -1") // 0xFFFFFFFF
-///
 /// let i64_val = ctx.getConstInt64(0L)
 /// let i64_m1 = ctx.getConstInt64(-1L)
 /// inspect(i64_val.or(i64_m1), content="i64 -1")
@@ -517,19 +485,15 @@ pub fn ConstantInt::or(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_6 = ctx.getConstInt8(6)     // 00000110
-/// let i8_3 = ctx.getConstInt8(3)     // 00000011
-/// inspect(i8_6.xor(i8_3), content="i8 5")  // 00000101
-///
+/// let i8_6 = ctx.getConstInt8(6) // 00000110
+/// let i8_3 = ctx.getConstInt8(3) // 00000011
+/// inspect(i8_6.xor(i8_3), content="i8 5") // 00000101
 /// let i16_val = ctx.getConstInt16(0xAA) // ...10101010
-/// let i16_m1 = ctx.getConstInt16(-1)   // ...11111111
+/// let i16_m1 = ctx.getConstInt16(-1) // ...11111111
 /// inspect(i16_val.xor(i16_m1), content="i16 -171") // ...01010101 (which is -0xAB or -171 for i16)
-///
 /// let i32_pattern = ctx.getConstInt32(0x0F0F0F0F)
 /// let i32_self_xor = i32_pattern.xor(i32_pattern)
 /// inspect(i32_self_xor, content="i32 0")
-///
 /// let i64_val = ctx.getConstInt64(12345L)
 /// let i64_0 = ctx.getConstInt64(0L)
 /// inspect(i64_val.xor(i64_0), content="i64 12345")
@@ -563,19 +527,15 @@ pub fn ConstantInt::xor(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_1 = ctx.getConstInt8(1)     // 00000001
-/// let i8_3 = ctx.getConstInt8(3)     // shift by 3
-/// inspect(i8_1.compute_shl(i8_3), content="i8 8")  // 00001000
-///
-/// let i16_5 = ctx.getConstInt16(5)   // ...00000101
-/// let i16_2 = ctx.getConstInt16(2)   // shift by 2
+/// let i8_1 = ctx.getConstInt8(1) // 00000001
+/// let i8_3 = ctx.getConstInt8(3) // shift by 3
+/// inspect(i8_1.compute_shl(i8_3), content="i8 8") // 00001000
+/// let i16_5 = ctx.getConstInt16(5) // ...00000101
+/// let i16_2 = ctx.getConstInt16(2) // shift by 2
 /// inspect(i16_5.compute_shl(i16_2), content="i16 20") // ...00010100
-///
 /// let i32_7 = ctx.getConstInt32(7)
 /// let i32_4 = ctx.getConstInt32(4)
 /// inspect(i32_7.compute_shl(i32_4), content="i32 112") // 7 << 4 = 112
-///
 /// let i64_val = ctx.getConstInt64(0x123L)
 /// let i64_8 = ctx.getConstInt64(8L)
 /// inspect(i64_val.compute_shl(i64_8), content="i64 74496") // 0x123 << 8 = 0x12300
@@ -609,19 +569,15 @@ pub fn ConstantInt::compute_shl(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_200 = ctx.getConstInt8(200)  // 11001000 (as unsigned)
-/// let i8_2 = ctx.getConstInt8(2)      // shift by 2
-/// inspect(i8_200.lshr(i8_2), content="i8 50")  // 00110010 (50)
-///
+/// let i8_200 = ctx.getConstInt8(200) // 11001000 (as unsigned)
+/// let i8_2 = ctx.getConstInt8(2) // shift by 2
+/// inspect(i8_200.lshr(i8_2), content="i8 50") // 00110010 (50)
 /// let i16_val = ctx.getConstInt16(-32768) // 1000000000000000
-/// let i16_1 = ctx.getConstInt16(1)         // shift by 1
+/// let i16_1 = ctx.getConstInt16(1) // shift by 1
 /// inspect(i16_val.lshr(i16_1), content="i16 16384") // 0100000000000000 (16384)
-///
-/// let i32_m1 = ctx.getConstInt32(-1)  // 0xFFFFFFFF
-/// let i32_4 = ctx.getConstInt32(4)    // shift by 4
+/// let i32_m1 = ctx.getConstInt32(-1) // 0xFFFFFFFF
+/// let i32_4 = ctx.getConstInt32(4) // shift by 4
 /// inspect(i32_m1.lshr(i32_4), content="i32 268435455") // 0x0FFFFFFF
-///
 /// let i64_val = ctx.getConstInt64(0x8000000000000000L) // MSB set
 /// let i64_1 = ctx.getConstInt64(1L)
 /// inspect(i64_val.lshr(i64_1), content="i64 4611686018427387904") // logical shift
@@ -673,19 +629,15 @@ pub fn ConstantInt::lshr(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8_m1 = ctx.getConstInt8(-1)   // 11111111
-/// let i8_2 = ctx.getConstInt8(2)     // shift by 2
-/// inspect(i8_m1.ashr(i8_2), content="i8 -1")  // 11111111 (sign extended)
-///
+/// let i8_m1 = ctx.getConstInt8(-1) // 11111111
+/// let i8_2 = ctx.getConstInt8(2) // shift by 2
+/// inspect(i8_m1.ashr(i8_2), content="i8 -1") // 11111111 (sign extended)
 /// let i16_m16 = ctx.getConstInt16(-16) // ...1111111111110000
-/// let i16_2 = ctx.getConstInt16(2)      // shift by 2
+/// let i16_2 = ctx.getConstInt16(2) // shift by 2
 /// inspect(i16_m16.ashr(i16_2), content="i16 -4") // ...1111111111111100
-///
 /// let i32_m8 = ctx.getConstInt32(-8)
 /// let i32_1 = ctx.getConstInt32(1)
 /// inspect(i32_m8.ashr(i32_1), content="i32 -4") // -8 >> 1 = -4 (arithmetic)
-///
 /// let i64_m128 = ctx.getConstInt64(-128L)
 /// let i64_3 = ctx.getConstInt64(3L)
 /// inspect(i64_m128.ashr(i64_3), content="i64 -16") // -128 >> 3 = -16
@@ -724,7 +676,6 @@ pub fn ConstantInt::ashr(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_5 = ctx.getConstInt8(5)
 /// let i8_10 = ctx.getConstInt8(10)
 /// let i8_m5 = ctx.getConstInt8(-5)
@@ -757,7 +708,7 @@ pub fn ConstantInt::ashr(
 ///
 /// // Test type mismatch
 /// let i16_5 = ctx.getConstInt16(5)
-/// assert_true({try? i8_5.compare(EQ, i16_5)} is Err(_))
+/// assert_true((try? i8_5.compare(EQ, i16_5)) is Err(_))
 /// ```
 pub fn ConstantInt::compare(
   self : ConstantInt,
@@ -845,22 +796,19 @@ pub fn ConstantInt::compare(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i32_255 = ctx.getConstInt32(255)
 /// let i8_255 = i32_255.trunc(ctx.getInt8Ty())
 /// inspect(i8_255, content="i8 -1")
-///
 /// let i64_0xFFFF = ctx.getConstInt64(0xFFFF)
 /// let i16_0xFFFF = i64_0xFFFF.trunc(ctx.getInt16Ty())
 /// inspect(i16_0xFFFF, content="i16 -1")
-///
 /// let i32_12345 = ctx.getConstInt32(12345)
 /// let i16_12345 = i32_12345.trunc(ctx.getInt16Ty())
 /// inspect(i16_12345, content="i16 12345")
 ///
 /// // Test error case: cannot truncate to larger type
 /// let i8_val = ctx.getConstInt8(42)
-/// assert_true({try? i8_val.trunc(ctx.getInt32Ty())} is Err(_))
+/// assert_true((try? i8_val.trunc(ctx.getInt32Ty())) is Err(_))
 /// ```
 pub fn ConstantInt::trunc(
   self : ConstantInt,
@@ -882,22 +830,19 @@ pub fn ConstantInt::trunc(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_255 = ctx.getConstInt8(255) // -1 as signed, 255 as unsigned
 /// let i32_255 = i8_255.zext(ctx.getInt32Ty())
 /// inspect(i32_255, content="i32 255")
-///
 /// let i1_true = ctx.getConstTrue()
 /// let i8_true = i1_true.zext(ctx.getInt8Ty())
 /// inspect(i8_true, content="i8 1")
-///
 /// let i16_42 = ctx.getConstInt16(42)
 /// let i64_42 = i16_42.zext(ctx.getInt64Ty())
 /// inspect(i64_42, content="i64 42")
 ///
 /// // Test error case: cannot zext to smaller type
 /// let i32_val = ctx.getConstInt32(42)
-/// assert_true({try? i32_val.zext(ctx.getInt8Ty())} is Err(_))
+/// assert_true((try? i32_val.zext(ctx.getInt8Ty())) is Err(_))
 /// ```
 pub fn ConstantInt::zext(
   self : ConstantInt,
@@ -927,22 +872,19 @@ pub fn ConstantInt::zext(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8_m1 = ctx.getConstInt8(-1)
 /// let i32_m1 = i8_m1.sext(ctx.getInt32Ty())
 /// inspect(i32_m1, content="i32 -1")
-///
 /// let i1_true = ctx.getConstTrue()
 /// let i8_true = i1_true.sext(ctx.getInt8Ty())
 /// inspect(i8_true, content="i8 -1")
-///
 /// let i16_42 = ctx.getConstInt16(42)
 /// let i64_42 = i16_42.sext(ctx.getInt64Ty())
 /// inspect(i64_42, content="i64 42")
 ///
 /// // Test error case: cannot sext to smaller type
 /// let i32_val = ctx.getConstInt32(42)
-/// assert_true({try? i32_val.sext(ctx.getInt8Ty())} is Err(_))
+/// assert_true((try? i32_val.sext(ctx.getInt8Ty())) is Err(_))
 /// ```
 pub fn ConstantInt::sext(
   self : ConstantInt,
@@ -968,15 +910,12 @@ pub fn ConstantInt::sext(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i32_255 = ctx.getConstInt32(255)
 /// let f32_255 = i32_255.uitofp(ctx.getFloatTy())
 /// assert_eq(f32_255.getValue(), 255.0)
-///
 /// let i8_m1 = ctx.getConstInt8(-1) // 255 as unsigned
 /// let f64_255 = i8_m1.uitofp(ctx.getDoubleTy())
 /// assert_eq(f64_255.getValue(), 255.0)
-///
 /// let i64_0 = ctx.getConstInt64(0)
 /// let f32_0 = i64_0.uitofp(ctx.getFloatTy())
 /// assert_eq(f32_0.getValue(), 0.0)
@@ -1002,15 +941,12 @@ pub fn ConstantInt::uitofp(self : ConstantInt, dst_ty : &FPType) -> ConstantFP {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i32_m42 = ctx.getConstInt32(-42)
 /// let f32_m42 = i32_m42.sitofp(ctx.getFloatTy())
 /// assert_eq(f32_m42.getValue(), -42.0)
-///
 /// let i8_127 = ctx.getConstInt8(127)
 /// let f64_127 = i8_127.sitofp(ctx.getDoubleTy())
 /// assert_eq(f64_127.getValue(), 127.0)
-///
 /// let i64_0 = ctx.getConstInt64(0)
 /// let f32_0 = i64_0.sitofp(ctx.getFloatTy())
 /// assert_eq(f32_0.getValue(), 0.0)
@@ -1030,11 +966,9 @@ pub fn ConstantInt::sitofp(self : ConstantInt, dst_ty : &FPType) -> ConstantFP {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i64_0 = ctx.getConstInt64(0)
 /// let null_ptr = i64_0.inttoptr()
 /// inspect(null_ptr, content="ptr null")
-///
 /// let i32_42 = ctx.getConstInt32(42)
 /// let ptr_42 = i32_42.inttoptr()
 /// inspect(ptr_42, content="ptr null") // Still null in constant folding
@@ -1068,7 +1002,7 @@ pub fn ConstantInt::inttoptr(self : ConstantInt) -> ConstantPointerNull {
 ///
 /// // Test error case: different bit widths
 /// let i8_val = ctx.getConstInt8(42)
-/// assert_true({try? i8_val.bitcast(ctx.getFloatTy())} is Err(_))
+/// assert_true((try? i8_val.bitcast(ctx.getFloatTy())) is Err(_))
 /// ```
 pub fn ConstantInt::bitcast(
   self : ConstantInt,
@@ -1219,12 +1153,10 @@ pub fn[T : Floating] ConstantFP::exactlyEquals(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32_0 = ctx.getConstFloat(0.0)
 /// let f32_1_5 = ctx.getConstFloat(1.5)
 /// let result1 = f32_0.add(f32_1_5)
 /// assert_eq(result1.getValue(), 1.5)
-///
 /// let f64_2_5 = ctx.getConstDouble(2.5)
 /// let f64_m1_5 = ctx.getConstDouble(-1.5)
 /// let result2 = f64_2_5.add(f64_m1_5)
@@ -1252,12 +1184,10 @@ pub fn ConstantFP::add(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32_0 = ctx.getConstFloat(0.0)
 /// let f32_1_5 = ctx.getConstFloat(1.5)
 /// let result1 = f32_0.sub(f32_1_5)
 /// assert_eq(result1.getValue(), -1.5)
-///
 /// let f64_2_5 = ctx.getConstDouble(2.5)
 /// let f64_m1_5 = ctx.getConstDouble(-1.5)
 /// let result2 = f64_2_5.sub(f64_m1_5)
@@ -1285,12 +1215,10 @@ pub fn ConstantFP::sub(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32_0 = ctx.getConstFloat(0.0)
 /// let f32_1_5 = ctx.getConstFloat(1.5)
 /// let result1 = f32_0.mul(f32_1_5)
 /// assert_eq(result1.getValue(), 0.0)
-///
 /// let f64_2_5 = ctx.getConstDouble(2.5)
 /// let f64_m1_5 = ctx.getConstDouble(-1.5)
 /// let result2 = f64_2_5.mul(f64_m1_5)
@@ -1318,16 +1246,14 @@ pub fn ConstantFP::mul(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32_0 = ctx.getConstFloat(0.0)
 /// let f32_1_5 = ctx.getConstFloat(1.5)
 /// let result1 = f32_0.div(f32_1_5)
 /// assert_eq(result1.getValue(), 0.0)
-///
 /// let f64_2_5 = ctx.getConstDouble(2.5)
 /// let f64_m1_5 = ctx.getConstDouble(-1.5)
 /// let result2 = f64_2_5.div(f64_m1_5)
-/// assert_eq(result2.getValue(), -5.0/3.0)
+/// assert_eq(result2.getValue(), -5.0 / 3.0)
 /// ```
 pub fn ConstantFP::div(
   self : ConstantFP,
@@ -1351,7 +1277,6 @@ pub fn ConstantFP::div(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32_1_5 = ctx.getConstFloat(1.5)
 /// let f32_2_5 = ctx.getConstFloat(2.5)
 /// let f32_nan = ctx.getConstFloat(0.0 / 0.0)
@@ -1392,7 +1317,7 @@ pub fn ConstantFP::div(
 ///
 /// // Test type mismatch
 /// let f64_1_5 = ctx.getConstDouble(1.5)
-/// assert_true({try? f32_1_5.compare(OEQ, f64_1_5)} is Err(_))
+/// assert_true((try? f32_1_5.compare(OEQ, f64_1_5)) is Err(_))
 /// ```
 pub fn ConstantFP::compare(
   self : ConstantFP,
@@ -1456,7 +1381,7 @@ pub fn ConstantFP::compare(
 ///
 /// // Test error case: cannot truncate to larger type
 /// let f32_val = ctx.getConstFloat(2.0)
-/// assert_true({try? f32_val.fptrunc(ctx.getDoubleTy())} is Err(_))
+/// assert_true((try? f32_val.fptrunc(ctx.getDoubleTy())) is Err(_))
 /// ```
 pub fn ConstantFP::fptrunc(
   self : ConstantFP,
@@ -1493,7 +1418,7 @@ pub fn ConstantFP::fptrunc(
 ///
 /// // Test error case: cannot extend to smaller type
 /// let f64_val = ctx.getConstDouble(2.0)
-/// assert_true({try? f64_val.fpext(ctx.getFloatTy())} is Err(_))
+/// assert_true((try? f64_val.fpext(ctx.getFloatTy())) is Err(_))
 /// ```
 pub fn ConstantFP::fpext(
   self : ConstantFP,
@@ -1613,11 +1538,11 @@ pub fn ConstantFP::fptosi(
 ///
 /// // Test f32 to f32 (same type should error)
 /// let f32_val = ctx.getConstFloat(1.0)
-/// assert_true({try? f32_val.bitcast(ctx.getFloatTy())} is Err(_))
+/// assert_true((try? f32_val.bitcast(ctx.getFloatTy())) is Err(_))
 ///
 /// // Test error case: different bit widths
 /// let f64_val = ctx.getConstDouble(42.0)
-/// assert_true({try? f64_val.bitcast(ctx.getInt32Ty())} is Err(_))
+/// assert_true((try? f64_val.bitcast(ctx.getInt32Ty())) is Err(_))
 /// ```
 pub fn ConstantFP::bitcast(
   self : ConstantFP,
@@ -2538,12 +2463,13 @@ pub impl Show for ConstantVector with output(self, logger) {
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
 /// let sty = ctx.getStructType([i32ty, f32ty])
-///
 /// let i32_val = ctx.getConstInt32(42)
 /// let f32_val = ctx.getConstFloat(3.14)
 /// let struct_val = ConstantStruct::new(sty, [i32_val, f32_val])
-///
-/// inspect(struct_val, content="{ i32, float } { i32 42, float 0x40091EB860000000 }")
+/// inspect(
+///   struct_val,
+///   content="{ i32, float } { i32 42, float 0x40091EB860000000 }",
+/// )
 /// ```
 pub struct ConstantStruct {
   // Unique identifier
@@ -2607,11 +2533,9 @@ pub fn ConstantStruct::getElement(
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
 /// let sty = ctx.getStructType([i32ty, f32ty])
-///
 /// let i32_val = ctx.getConstInt32(42)
 /// let f32_val = ctx.getConstFloat(3.14)
 /// let struct_val = ConstantStruct::new(sty, [i32_val, f32_val])
-///
 /// inspect(struct_val.extractValue([0]), content="Some(i32 42)")
 /// inspect(struct_val.extractValue([1]), content="Some(float 0x40091EB860000000)")
 /// inspect(struct_val.extractValue([2]), content="None") // Out of bounds
@@ -2649,7 +2573,6 @@ pub fn ConstantStruct::extractValue(
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
 /// let sty = ctx.getStructType([i32ty, f32ty])
-///
 /// let i32_val = ctx.getConstInt32(42)
 /// let f32_val = ctx.getConstFloat(3.14)
 /// let struct_val = ConstantStruct::new(sty, [i32_val, f32_val])

--- a/IR/Context.mbt
+++ b/IR/Context.mbt
@@ -105,7 +105,7 @@ pub fn Context::createBuilder(self : Context) -> IRBuilder {
 ///
 /// - See LLVM: `Type::getHalfTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let half_ty = ctx.getHalfTy()
 /// inspect(half_ty, content="half")
@@ -119,7 +119,7 @@ pub fn Context::getHalfTy(self : Context) -> HalfType {
 ///
 /// - See LLVM: `Type::getBFloatTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let bfloat_ty = ctx.getBFloatTy()
 /// inspect(bfloat_ty, content="bfloat")
@@ -133,7 +133,7 @@ pub fn Context::getBFloatTy(self : Context) -> BFloatType {
 ///
 /// - See LLVM: `Type::getFloatTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let f32ty = ctx.getFloatTy()
 /// inspect(f32ty, content="float")
@@ -147,7 +147,7 @@ pub fn Context::getFloatTy(self : Context) -> FloatType {
 ///
 /// - See LLVM: `Type::getDoubleTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let doubletype = ctx.getDoubleTy()
 /// inspect(doubletype, content="double")
@@ -161,7 +161,7 @@ pub fn Context::getDoubleTy(self : Context) -> DoubleType {
 ///
 /// - See LLVM: `Type::getFP128Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let fp128ty = ctx.getFP128Ty()
 /// inspect(fp128ty, content="fp128")
@@ -175,7 +175,7 @@ pub fn Context::getFP128Ty(self : Context) -> FP128Type {
 ///
 /// - See LLVM: `Type::getVoidTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let voidty = ctx.getVoidTy()
 /// inspect(voidty, content="void")
@@ -201,7 +201,7 @@ pub fn Context::getMetadataTy(self : Context) -> MetadataType {
 ///
 /// - See LLVM: `Type::getTokenTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let tokenty = ctx.getTokenTy()
 /// inspect(tokenty, content="token")
@@ -250,7 +250,7 @@ pub fn Context::getInt64Ty(self : Context) -> Int64Type {
 ///   After LLVM17, typed pointer has been deprecated. Therefore in 
 ///   Moonbit Aether framework, all pointer type is opaque.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getPtrTy(), content="ptr")
@@ -282,7 +282,7 @@ pub fn Context::getPtrTy(
 ///
 /// - See LLVM: `FunctionType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let voidty = ctx.getVoidTy()
 /// let i32ty = ctx.getInt32Ty()
@@ -311,7 +311,7 @@ pub fn Context::getFunctionType(
 ///
 /// - See LLVM: `StructType::create`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -342,7 +342,7 @@ pub fn Context::getStructType(
 ///
 /// LLVM Cpp version has no this method, since llvm-cpp allow duplicated struct type names.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -367,7 +367,7 @@ pub fn Context::getStructTypeByName(self : Self, name : String) -> StructType? {
 ///
 /// - See LLVM: `ArrayType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 ///
@@ -393,7 +393,7 @@ pub fn Context::getArrayType(
 ///
 /// - See LLVM: `VectorType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 ///
@@ -416,7 +416,7 @@ pub fn Context::getFixedVectorType(
 ///
 /// - See LLVM: `ScalableVectorType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 ///
@@ -436,7 +436,7 @@ pub fn Context::getScalableVectorType(
 ///
 /// - See LLVM: `ConstantInt::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstInt8(0), content="i8 0")
 /// inspect(ctx.getConstInt8(1), content="i8 1")
@@ -452,7 +452,7 @@ pub fn Context::getConstInt8(self : Context, value : Int) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstInt16(0), content="i16 0")
 /// inspect(ctx.getConstInt16(1), content="i16 1")
@@ -467,7 +467,7 @@ pub fn Context::getConstInt16(self : Context, value : Int16) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstInt32(0), content="i32 0")
 /// inspect(ctx.getConstInt32(1), content="i32 1")
@@ -482,7 +482,7 @@ pub fn Context::getConstInt32(self : Context, value : Int) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstInt64(0), content="i64 0")
 /// inspect(ctx.getConstInt64(1), content="i64 1")
@@ -497,7 +497,7 @@ pub fn Context::getConstInt64(self : Context, value : Int64) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::getTrue`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstTrue(), content="i1 true")
 /// ```
@@ -510,7 +510,7 @@ pub fn Context::getConstTrue(self : Context) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::getFalse`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// inspect(ctx.getConstFalse(), content="i1 false")
 /// ```
@@ -523,7 +523,7 @@ pub fn Context::getConstFalse(self : Context) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantInt::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getConstBool(true), content="i1 true")
@@ -538,7 +538,7 @@ pub fn Context::getConstBool(self : Context, b : Bool) -> ConstantInt {
 ///
 /// - See LLVM: `ConstantFP::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let one = ctx.getConstFloat(1.0)
@@ -555,7 +555,7 @@ pub fn Context::getConstFloat(self : Context, value : Float) -> ConstantFP {
 ///
 /// - See LLVM: `ConstantFP::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let one = ctx.getConstDouble(1.0)
@@ -577,7 +577,7 @@ pub fn Context::getConstDouble(self : Context, value : Double) -> ConstantFP {
 ///
 ///  - `isNegative`: If true, create a negative zero constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let zero = ctx.getConstZeroFloat()
@@ -606,7 +606,7 @@ pub fn Context::getConstZeroFloat(
 ///
 /// - `isNegative`: If true, create a negative zero constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let zero = ctx.getConstZeroDouble()
@@ -635,7 +635,7 @@ pub fn Context::getConstZeroDouble(
 ///
 /// - `isNegative`: If true, create a negative zero constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstNaNDouble()
@@ -664,7 +664,7 @@ pub fn Context::getConstNaNFloat(
 ///
 /// - `isNegative`: If true, create a negative NaN constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstQNaNFloat()
@@ -693,7 +693,7 @@ pub fn Context::getConstQNaNFloat(
 ///
 /// - `isNegative`: If true, create a negative NaN constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstSNaNFloat()
@@ -722,7 +722,7 @@ pub fn Context::getConstSNaNFloat(
 ///
 /// - `isNegative`: If true, create a negative Infinity constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let inf = ctx.getConstInfFloat()
@@ -751,7 +751,7 @@ pub fn Context::getConstInfFloat(
 ///
 /// - `isNegative`: If true, create a negative NaN constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstNaNDouble()
@@ -780,7 +780,7 @@ pub fn Context::getConstNaNDouble(
 ///
 /// - `isNegative`: If true, create a negative NaN constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstQNaNDouble()
@@ -809,7 +809,7 @@ pub fn Context::getConstQNaNDouble(
 ///
 /// - `isNegative`: If true, create a negative NaN constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let nan = ctx.getConstSNaNDouble()
@@ -838,7 +838,7 @@ pub fn Context::getConstSNaNDouble(
 ///
 /// - `isNegative`: If true, create a negative Infinity constant.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let inf = ctx.getConstInfDouble()
@@ -868,7 +868,7 @@ pub fn Context::getConstInfDouble(
 /// - Core does not support `int8` currently, hence the type
 /// of parameter `data` is `Array[Int]`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int] = [42, 63, 77, 89]
@@ -888,7 +888,7 @@ pub fn Context::getConstInt8Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int16] = [42, 63, 77, 89]
@@ -908,7 +908,7 @@ pub fn Context::getConstInt16Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int] = [42, 63, 77, 89]
@@ -928,7 +928,7 @@ pub fn Context::getConstInt32Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int64] = [42, 63, 77, 89]
@@ -948,7 +948,7 @@ pub fn Context::getConstInt64Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Byte] = [42, 63, 77, 89]
@@ -969,7 +969,7 @@ pub fn Context::getConstUInt8Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt16] = [42, 63, 77, 89]
@@ -990,7 +990,7 @@ pub fn Context::getConstUInt16Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt] = [42, 63, 77, 89]
@@ -1011,7 +1011,7 @@ pub fn Context::getConstUInt32Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt64] = [42, 63, 77, 89]
@@ -1032,7 +1032,7 @@ pub fn Context::getConstUInt64Array(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Float] = [1.0, 2.0]
@@ -1056,7 +1056,7 @@ pub fn Context::getConstFloatArray(
 ///
 /// -  See LLVM: `ConstantDataArray::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Double] = [1.0, 2.0]
@@ -1099,7 +1099,7 @@ pub fn Context::getConstArray(
 /// - Core does not support `int8` currently, hence the type
 /// of parameter `data` is `Array[Int]`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int] = [42, 63, 77, 89]
@@ -1120,7 +1120,7 @@ pub fn Context::getConstInt8Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int16] = [42, 63, 77, 89]
@@ -1141,7 +1141,7 @@ pub fn Context::getConstInt16Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int] = [42, 63, 77, 89]
@@ -1162,7 +1162,7 @@ pub fn Context::getConstInt32Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Int64] = [42, 63, 77, 89]
@@ -1183,7 +1183,7 @@ pub fn Context::getConstInt64Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Byte] = [42, 63, 77, 89]
@@ -1203,7 +1203,7 @@ pub fn Context::getConstUInt8Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt16] = [42, 63, 77, 89]
@@ -1223,7 +1223,7 @@ pub fn Context::getConstUInt16Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt] = [42, 63, 77, 89]
@@ -1243,7 +1243,7 @@ pub fn Context::getConstUInt32Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[UInt64] = [42, 63, 77, 89]
@@ -1263,7 +1263,7 @@ pub fn Context::getConstUInt64Vector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Float] = [1.0, 2.0]
@@ -1286,7 +1286,7 @@ pub fn Context::getConstFloatVector(
 ///
 /// -  See LLVM: `ConstantDataVector::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let data : Array[Double] = [1.0, 2.0]
@@ -1310,7 +1310,7 @@ pub fn Context::getConstDoubleVector(
 ///
 /// TODO: wait compiler bug fixed.
 ///
-/// ```moonbit-no-run
+/// ```mbt test-no-run
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let zero_i32 = ctx.getConstZero(i32ty)

--- a/IR/Context.mbt
+++ b/IR/Context.mbt
@@ -252,9 +252,7 @@ pub fn Context::getInt64Ty(self : Context) -> Int64Type {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getPtrTy(), content="ptr")
-///
 /// let addressSpace = AddressSpace::new(1)
 /// inspect(ctx.getPtrTy(addressSpace~), content="ptr")
 /// ```
@@ -287,7 +285,6 @@ pub fn Context::getPtrTy(
 /// let voidty = ctx.getVoidTy()
 /// let i32ty = ctx.getInt32Ty()
 /// let f64ty = ctx.getDoubleTy()
-///
 /// let fty = ctx.getFunctionType(voidty, [i32ty, f64ty])
 /// inspect(fty, content="void (i32, double)")
 /// ```
@@ -316,8 +313,7 @@ pub fn Context::getFunctionType(
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
 /// let f64ty = ctx.getDoubleTy()
-///
-/// let sty = ctx.getStructType([i32ty, f32ty, f64ty], name = "foo")
+/// let sty = ctx.getStructType([i32ty, f32ty, f64ty], name="foo")
 /// inspect(sty.full_info(), content="%foo = type { i32, float, double }")
 ///
 /// // Cannot create a ananymous struct type with empty elements.
@@ -346,11 +342,8 @@ pub fn Context::getStructType(
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
-///
 /// let _ = ctx.getStructType([i32ty, f32ty], name="foo")
-///
 /// let sty = ctx.getStructTypeByName("foo").unwrap()
-///
 /// inspect(sty.full_info(), content="%foo = type { i32, float }")
 /// ```
 pub fn Context::getStructTypeByName(self : Self, name : String) -> StructType? {
@@ -370,11 +363,9 @@ pub fn Context::getStructTypeByName(self : Self, name : String) -> StructType? {
 /// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
-///
 /// let arrty = ctx.getArrayType(i32ty, 16)
 /// inspect(arrty, content="[16 x i32]")
 /// inspect(arrty.getElementType(), content="i32")
-///
 /// assert_eq(arrty.getElementCount(), 16)
 /// ```
 pub fn Context::getArrayType(
@@ -396,7 +387,6 @@ pub fn Context::getArrayType(
 /// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
-///
 /// let fixedVecTy = ctx.getFixedVectorType(i32ty, 32)
 /// inspect(fixedVecTy, content="<32 x i32>")
 /// ```
@@ -419,7 +409,6 @@ pub fn Context::getFixedVectorType(
 /// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
-///
 /// let scalableVecTy = ctx.getScalableVectorType(i32ty, 16)
 /// inspect(scalableVecTy, content="<vscale x 16 x i32>")
 /// ```
@@ -525,7 +514,6 @@ pub fn Context::getConstFalse(self : Context) -> ConstantInt {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getConstBool(true), content="i1 true")
 /// inspect(ctx.getConstBool(false), content="i1 false")
 /// ```
@@ -540,7 +528,6 @@ pub fn Context::getConstBool(self : Context, b : Bool) -> ConstantInt {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let one = ctx.getConstFloat(1.0)
 /// let two = ctx.getConstFloat(2.0)
 /// inspect(one, content="float 0x3FF0000000000000")
@@ -557,10 +544,8 @@ pub fn Context::getConstFloat(self : Context, value : Float) -> ConstantFP {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let one = ctx.getConstDouble(1.0)
 /// let two = ctx.getConstDouble(2.0)
-///
 /// inspect(one, content="double 0x3FF0000000000000")
 /// inspect(two, content="double 0x4000000000000000")
 /// ```
@@ -579,10 +564,8 @@ pub fn Context::getConstDouble(self : Context, value : Double) -> ConstantFP {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let zero = ctx.getConstZeroFloat()
 /// let neg_zero = ctx.getConstZeroFloat(isNegative=true)
-///
 /// inspect(zero, content="float 0x0")
 /// inspect(neg_zero, content="float 0x8000000000000000")
 /// ```
@@ -608,10 +591,8 @@ pub fn Context::getConstZeroFloat(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let zero = ctx.getConstZeroDouble()
 /// let neg_zero = ctx.getConstZeroDouble(isNegative=true)
-///
 /// inspect(zero, content="double 0x0")
 /// inspect(neg_zero, content="double 0x8000000000000000")
 /// ```
@@ -637,10 +618,8 @@ pub fn Context::getConstZeroDouble(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstNaNDouble()
 /// let neg_nan = ctx.getConstNaNDouble(isNegative=true)
-///
 /// inspect(nan, content="double 0x7FF8000000000000")
 /// inspect(neg_nan, content="double 0xFFF8000000000000")
 /// ```
@@ -666,10 +645,8 @@ pub fn Context::getConstNaNFloat(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstQNaNFloat()
 /// let neg_nan = ctx.getConstQNaNFloat(isNegative=true)
-///
 /// inspect(nan, content="float 0x7FF8000000000000")
 /// inspect(neg_nan, content="float 0xFFF8000000000000")
 /// ```
@@ -695,10 +672,8 @@ pub fn Context::getConstQNaNFloat(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstSNaNFloat()
 /// let neg_nan = ctx.getConstSNaNFloat(isNegative=true)
-///
 /// inspect(nan, content="float 0x7FF4000000000000")
 /// inspect(neg_nan, content="float 0xFFF4000000000000")
 /// ```
@@ -724,10 +699,8 @@ pub fn Context::getConstSNaNFloat(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let inf = ctx.getConstInfFloat()
 /// let neg_inf = ctx.getConstInfFloat(isNegative=true)
-///
 /// inspect(inf, content="float 0x7FF0000000000000")
 /// inspect(neg_inf, content="float 0xFFF0000000000000")
 /// ```
@@ -753,10 +726,8 @@ pub fn Context::getConstInfFloat(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstNaNDouble()
 /// let neg_nan = ctx.getConstNaNDouble(isNegative=true)
-///
 /// inspect(nan, content="double 0x7FF8000000000000")
 /// inspect(neg_nan, content="double 0xFFF8000000000000")
 /// ```
@@ -782,10 +753,8 @@ pub fn Context::getConstNaNDouble(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstQNaNDouble()
 /// let neg_nan = ctx.getConstQNaNDouble(isNegative=true)
-///
 /// inspect(nan, content="double 0x7FF8000000000000")
 /// inspect(neg_nan, content="double 0xFFF8000000000000")
 /// ```
@@ -811,10 +780,8 @@ pub fn Context::getConstQNaNDouble(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let nan = ctx.getConstSNaNDouble()
 /// let neg_nan = ctx.getConstSNaNDouble(isNegative=true)
-///
 /// inspect(nan, content="double 0x7FF4000000000000")
 /// inspect(neg_nan, content="double 0xFFF4000000000000")
 /// ```
@@ -840,10 +807,8 @@ pub fn Context::getConstSNaNDouble(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let inf = ctx.getConstInfDouble()
 /// let neg_inf = ctx.getConstInfDouble(isNegative=true)
-///
 /// inspect(inf, content="double 0x7FF0000000000000")
 /// inspect(neg_inf, content="double 0xFFF0000000000000")
 /// ```
@@ -870,7 +835,6 @@ pub fn Context::getConstInfDouble(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt8Array(data)
 /// inspect(arr, content="[4 x i8] [i8 42, i8 63, i8 77, i8 89]")
@@ -890,7 +854,6 @@ pub fn Context::getConstInt8Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int16] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt16Array(data)
 /// inspect(arr, content="[4 x i16] [i16 42, i16 63, i16 77, i16 89]")
@@ -910,7 +873,6 @@ pub fn Context::getConstInt16Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt32Array(data)
 /// inspect(arr, content="[4 x i32] [i32 42, i32 63, i32 77, i32 89]")
@@ -930,7 +892,6 @@ pub fn Context::getConstInt32Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int64] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt64Array(data)
 /// inspect(arr, content="[4 x i64] [i64 42, i64 63, i64 77, i64 89]")
@@ -950,7 +911,6 @@ pub fn Context::getConstInt64Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Byte] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt8Array(data)
 /// inspect(arr, content="[4 x i8] [i8 42, i8 63, i8 77, i8 89]")
@@ -971,7 +931,6 @@ pub fn Context::getConstUInt8Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt16] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt16Array(data)
 /// inspect(arr, content="[4 x i16] [i16 42, i16 63, i16 77, i16 89]")
@@ -992,7 +951,6 @@ pub fn Context::getConstUInt16Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt32Array(data)
 /// inspect(arr, content="[4 x i32] [i32 42, i32 63, i32 77, i32 89]")
@@ -1013,7 +971,6 @@ pub fn Context::getConstUInt32Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt64] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt64Array(data)
 /// inspect(arr, content="[4 x i64] [i64 42, i64 63, i64 77, i64 89]")
@@ -1034,12 +991,11 @@ pub fn Context::getConstUInt64Array(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Float] = [1.0, 2.0]
 /// let arr = ctx.getConstFloatArray(data)
 /// inspect(
 ///   arr,
-///   content="[2 x float] [float 0x3FF0000000000000, float 0x4000000000000000]"
+///   content="[2 x float] [float 0x3FF0000000000000, float 0x4000000000000000]",
 /// )
 /// ```
 pub fn Context::getConstFloatArray(
@@ -1058,13 +1014,11 @@ pub fn Context::getConstFloatArray(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Double] = [1.0, 2.0]
 /// let arr = ctx.getConstDoubleArray(data)
-///
 /// inspect(
 ///   arr,
-///   content="[2 x double] [double 0x3FF0000000000000, double 0x4000000000000000]"
+///   content="[2 x double] [double 0x3FF0000000000000, double 0x4000000000000000]",
 /// )
 /// ```
 pub fn Context::getConstDoubleArray(
@@ -1101,7 +1055,6 @@ pub fn Context::getConstArray(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt8Vector(data)
 /// inspect(arr, content="<4 x i8> <i8 42, i8 63, i8 77, i8 89>")
@@ -1122,7 +1075,6 @@ pub fn Context::getConstInt8Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int16] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt16Vector(data)
 /// inspect(arr, content="<4 x i16> <i16 42, i16 63, i16 77, i16 89>")
@@ -1143,7 +1095,6 @@ pub fn Context::getConstInt16Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt32Vector(data)
 /// inspect(arr, content="<4 x i32> <i32 42, i32 63, i32 77, i32 89>")
@@ -1164,7 +1115,6 @@ pub fn Context::getConstInt32Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Int64] = [42, 63, 77, 89]
 /// let arr = ctx.getConstInt64Vector(data)
 /// inspect(arr, content="<4 x i64> <i64 42, i64 63, i64 77, i64 89>")
@@ -1185,7 +1135,6 @@ pub fn Context::getConstInt64Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Byte] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt8Vector(data)
 /// inspect(arr, content="<4 x i8> <i8 42, i8 63, i8 77, i8 89>")
@@ -1205,7 +1154,6 @@ pub fn Context::getConstUInt8Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt16] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt16Vector(data)
 /// inspect(arr, content="<4 x i16> <i16 42, i16 63, i16 77, i16 89>")
@@ -1225,7 +1173,6 @@ pub fn Context::getConstUInt16Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt32Vector(data)
 /// inspect(arr, content="<4 x i32> <i32 42, i32 63, i32 77, i32 89>")
@@ -1245,7 +1192,6 @@ pub fn Context::getConstUInt32Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[UInt64] = [42, 63, 77, 89]
 /// let arr = ctx.getConstUInt64Vector(data)
 /// inspect(arr, content="<4 x i64> <i64 42, i64 63, i64 77, i64 89>")
@@ -1265,12 +1211,11 @@ pub fn Context::getConstUInt64Vector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Float] = [1.0, 2.0]
 /// let arr = ctx.getConstFloatVector(data)
 /// inspect(
 ///   arr,
-///   content="<2 x float> <float 0x3FF0000000000000, float 0x4000000000000000>"
+///   content="<2 x float> <float 0x3FF0000000000000, float 0x4000000000000000>",
 /// )
 /// ```
 pub fn Context::getConstFloatVector(
@@ -1288,13 +1233,11 @@ pub fn Context::getConstFloatVector(
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let data : Array[Double] = [1.0, 2.0]
 /// let arr = ctx.getConstDoubleVector(data)
-///
 /// inspect(
 ///   arr,
-///   content="<2 x double> <double 0x3FF0000000000000, double 0x4000000000000000>"
+///   content="<2 x double> <double 0x3FF0000000000000, double 0x4000000000000000>",
 /// )
 /// ```
 pub fn Context::getConstDoubleVector(

--- a/IR/DataLayout.mbt
+++ b/IR/DataLayout.mbt
@@ -85,7 +85,7 @@ pub fn DataLayout::getEndian(self : DataLayout) -> Endian {
 ///
 /// **Examples:**
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let datalayout = mod.getDataLayout()
@@ -234,7 +234,7 @@ fn DataLayout::getAlignment(self : DataLayout, ty : &Type) -> Align {
 ///
 /// **Examples:**
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let datalayout = mod.getDataLayout()

--- a/IR/DataLayout.mbt
+++ b/IR/DataLayout.mbt
@@ -238,7 +238,6 @@ fn DataLayout::getAlignment(self : DataLayout, ty : &Type) -> Align {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let datalayout = mod.getDataLayout()
-///
 /// let i8ty = ctx.getInt8Ty()
 /// let i32ty = ctx.getInt32Ty()
 /// let i64ty = ctx.getInt64Ty()

--- a/IR/Function.mbt
+++ b/IR/Function.mbt
@@ -7,7 +7,7 @@
 ///
 /// - See `llvm::Argument`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let prog = ctx.addModule("demo")
 ///
@@ -54,7 +54,7 @@ fn Argument::new(vty : &Type, argNo : UInt, parent : Function) -> Argument {
 ///
 /// - See `llvm::Argument::addAttribute`.
 ///
-/// ```moonbit`
+/// ```mbt test`
 /// let ctx = Context::new()
 /// let prog = ctx.addModule("demo")
 ///
@@ -118,7 +118,7 @@ pub impl Value for Argument with getName(self : Argument) -> String? {
 ///
 /// - See `llvm::Argument::setName`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let prog = ctx.addModule("demo")
 ///

--- a/IR/Function.mbt
+++ b/IR/Function.mbt
@@ -10,15 +10,11 @@
 /// ```mbt test
 /// let ctx = Context::new()
 /// let prog = ctx.addModule("demo")
-///
 /// let i32ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32ty, [i32ty, i32ty])
-///
 /// let f = prog.addFunction(fty, "add")
-///
 /// let arg0 = f.getArg(0).unwrap()
 /// let arg1 = f.getArg(1).unwrap()
-///
 /// inspect(arg0, content="i32 %0")
 /// inspect(arg1.getType(), content="i32")
 /// assert_true(f.getArg(2) is None)
@@ -121,25 +117,19 @@ pub impl Value for Argument with getName(self : Argument) -> String? {
 /// ```mbt test
 /// let ctx = Context::new()
 /// let prog = ctx.addModule("demo")
-///
 /// let i32ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32ty, [i32ty, i32ty])
-///
 /// let f = prog.addFunction(fty, "add")
-///
 /// let arg0 = f.getArg(0).unwrap()
 /// let arg1 = f.getArg(1).unwrap()
-///
 /// assert_true(f.getArg(2) is None)
 /// inspect(arg0, content="i32 %0")
 /// inspect(arg1.getType(), content="i32")
-///
 /// arg0.setName("lhs")
 /// arg1.setName("rhs")
 /// inspect(arg0, content="i32 %lhs")
 /// inspect(arg1, content="i32 %rhs")
-///
-/// assert_true({try? arg1.setName("lhs")} is Err(_))
+/// assert_true((try? arg1.setName("lhs")) is Err(_))
 /// ```
 pub impl Value for Argument with setName(self : Argument, name : String) -> Unit raise LLVMValueError {
   if name.is_empty() {

--- a/IR/IRBuilder.mbt
+++ b/IR/IRBuilder.mbt
@@ -96,18 +96,14 @@ pub fn IRBuilder::getModule(self : IRBuilder) -> Module {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "direct_ret")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let ret = builder.createRet(arg)
-///
-/// inspect(ret, content = "  ret i32 %0")
+/// inspect(ret, content="  ret i32 %0")
 /// ```
 pub fn IRBuilder::createRet(
   self : IRBuilder,
@@ -139,17 +135,13 @@ pub fn IRBuilder::createRet(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "direct_ret")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let ret = builder.createRetVoid()
-///
-/// inspect(ret, content = "  ret void")
+/// inspect(ret, content="  ret void")
 /// ```
 pub fn IRBuilder::createRetVoid(self : IRBuilder) -> &Instruction raise Error {
   let parent = self.getInsertFunction()
@@ -171,18 +163,14 @@ pub fn IRBuilder::createRetVoid(self : IRBuilder) -> &Instruction raise Error {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "foo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let inst = builder.createAlloca(i32_ty, name="var1")
-///
-/// inspect(inst, content = "  %var1 = alloca i32, align 4")
+/// inspect(inst, content="  %var1 = alloca i32, align 4")
 /// ```
 pub fn IRBuilder::createAlloca(
   self : IRBuilder,
@@ -215,24 +203,20 @@ pub fn IRBuilder::createAlloca(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "add_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createAdd(arg1, arg2, name="sum")
-/// inspect(add, content = "  %sum = add i32 %0, %1")
+/// inspect(add, content="  %sum = add i32 %0, %1")
 /// assert_true(add.asValueEnum() is BinaryInst(_))
-///
 /// let one = ctx.getConstInt32(1)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createAdd(one, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createAdd(
@@ -295,24 +279,20 @@ pub fn IRBuilder::createAdd(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nsw_add_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createNSWAdd(arg1, arg2, name="sum")
-/// inspect(add, content = "  %sum = add nsw i32 %0, %1")
+/// inspect(add, content="  %sum = add nsw i32 %0, %1")
 /// assert_true(add.asValueEnum() is BinaryInst(_))
-///
 /// let one = ctx.getConstInt32(1)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createNSWAdd(one, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNSWAdd(
@@ -335,24 +315,20 @@ pub fn IRBuilder::createNSWAdd(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nuw_add_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createNUWAdd(arg1, arg2, name="sum")
-/// inspect(add, content = "  %sum = add nuw i32 %0, %1")
+/// inspect(add, content="  %sum = add nuw i32 %0, %1")
 /// assert_true(add.asValueEnum() is BinaryInst(_))
-///
 /// let one = ctx.getConstInt32(1)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createNUWAdd(one, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNUWAdd(
@@ -375,24 +351,20 @@ pub fn IRBuilder::createNUWAdd(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "sub_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let sub = builder.createSub(arg1, arg2, name="diff")
-/// inspect(sub, content = "  %diff = sub i32 %0, %1")
+/// inspect(sub, content="  %diff = sub i32 %0, %1")
 /// assert_true(sub.asValueEnum() is BinaryInst(_))
-///
 /// let five = ctx.getConstInt32(5)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createSub(five, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createSub(
@@ -455,24 +427,20 @@ pub fn IRBuilder::createSub(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nsw_sub_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let sub = builder.createNSWSub(arg1, arg2, name="diff")
-/// inspect(sub, content = "  %diff = sub nsw i32 %0, %1")
+/// inspect(sub, content="  %diff = sub nsw i32 %0, %1")
 /// assert_true(sub.asValueEnum() is BinaryInst(_))
-///
 /// let five = ctx.getConstInt32(5)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createNSWSub(five, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNSWSub(
@@ -495,24 +463,20 @@ pub fn IRBuilder::createNSWSub(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nuw_sub_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let sub = builder.createNUWSub(arg1, arg2, name="diff")
-/// inspect(sub, content = "  %diff = sub nuw i32 %0, %1")
+/// inspect(sub, content="  %diff = sub nuw i32 %0, %1")
 /// assert_true(sub.asValueEnum() is BinaryInst(_))
-///
 /// let five = ctx.getConstInt32(5)
 /// let two = ctx.getConstInt32(2)
 /// let three = builder.createNUWSub(five, two)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content="i32 3")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNUWSub(
@@ -546,24 +510,20 @@ pub fn IRBuilder::createNeg(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "mul_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let mul = builder.createMul(arg1, arg2, name="product")
-/// inspect(mul, content = "  %product = mul i32 %0, %1")
+/// inspect(mul, content="  %product = mul i32 %0, %1")
 /// assert_true(mul.asValueEnum() is BinaryInst(_))
-///
 /// let three = ctx.getConstInt32(3)
 /// let four = ctx.getConstInt32(4)
 /// let twelve = builder.createMul(three, four)
-/// inspect(twelve, content = "i32 12")
+/// inspect(twelve, content="i32 12")
 /// assert_true(twelve.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createMul(
@@ -626,24 +586,20 @@ pub fn IRBuilder::createMul(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nsw_mul_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let mul = builder.createNSWMul(arg1, arg2, name="product")
-/// inspect(mul, content = "  %product = mul nsw i32 %0, %1")
+/// inspect(mul, content="  %product = mul nsw i32 %0, %1")
 /// assert_true(mul.asValueEnum() is BinaryInst(_))
-///
 /// let three = ctx.getConstInt32(3)
 /// let four = ctx.getConstInt32(4)
 /// let twelve = builder.createNSWMul(three, four)
-/// inspect(twelve, content = "i32 12")
+/// inspect(twelve, content="i32 12")
 /// assert_true(twelve.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNSWMul(
@@ -666,24 +622,20 @@ pub fn IRBuilder::createNSWMul(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "nuw_mul_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let mul = builder.createNUWMul(arg1, arg2, name="product")
-/// inspect(mul, content = "  %product = mul nuw i32 %0, %1")
+/// inspect(mul, content="  %product = mul nuw i32 %0, %1")
 /// assert_true(mul.asValueEnum() is BinaryInst(_))
-///
 /// let three = ctx.getConstInt32(3)
 /// let four = ctx.getConstInt32(4)
 /// let twelve = builder.createNUWMul(three, four)
-/// inspect(twelve, content = "i32 12")
+/// inspect(twelve, content="i32 12")
 /// assert_true(twelve.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createNUWMul(
@@ -1252,17 +1204,14 @@ pub fn IRBuilder::createFSub(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fneg_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let fneg = builder.createFNeg(arg, name="neg_value")
-/// inspect(fneg, content = "  %neg_value = fneg float %0")
+/// inspect(fneg, content="  %neg_value = fneg float %0")
 /// assert_true(fneg.asValueEnum() is FNegInst(_))
 /// ```
 pub fn IRBuilder::createFNeg(
@@ -1503,24 +1452,20 @@ pub fn IRBuilder::createFRem(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "and_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let and_result = builder.createAnd(arg1, arg2, name="result")
-/// inspect(and_result, content = "  %result = and i32 %0, %1")
+/// inspect(and_result, content="  %result = and i32 %0, %1")
 /// assert_true(and_result.asValueEnum() is BinaryInst(_))
-///
-/// let val1 = ctx.getConstInt32(12)  // 1100 in binary
-/// let val2 = ctx.getConstInt32(10)  // 1010 in binary
-/// let result = builder.createAnd(val1, val2)  // 1000 in binary = 8
-/// inspect(result, content = "i32 8")
+/// let val1 = ctx.getConstInt32(12) // 1100 in binary
+/// let val2 = ctx.getConstInt32(10) // 1010 in binary
+/// let result = builder.createAnd(val1, val2) // 1000 in binary = 8
+/// inspect(result, content="i32 8")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createAnd(
@@ -1575,24 +1520,20 @@ pub fn IRBuilder::createAnd(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "or_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let or_result = builder.createOr(arg1, arg2, name="result")
-/// inspect(or_result, content = "  %result = or i32 %0, %1")
+/// inspect(or_result, content="  %result = or i32 %0, %1")
 /// assert_true(or_result.asValueEnum() is BinaryInst(_))
-///
-/// let val1 = ctx.getConstInt32(12)  // 1100 in binary
-/// let val2 = ctx.getConstInt32(10)  // 1010 in binary
-/// let result = builder.createOr(val1, val2)  // 1110 in binary = 14
-/// inspect(result, content = "i32 14")
+/// let val1 = ctx.getConstInt32(12) // 1100 in binary
+/// let val2 = ctx.getConstInt32(10) // 1010 in binary
+/// let result = builder.createOr(val1, val2) // 1110 in binary = 14
+/// inspect(result, content="i32 14")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createOr(
@@ -1647,24 +1588,20 @@ pub fn IRBuilder::createOr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "xor_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let xor_result = builder.createXor(arg1, arg2, name="result")
-/// inspect(xor_result, content = "  %result = xor i32 %0, %1")
+/// inspect(xor_result, content="  %result = xor i32 %0, %1")
 /// assert_true(xor_result.asValueEnum() is BinaryInst(_))
-///
-/// let val1 = ctx.getConstInt32(12)  // 1100 in binary
-/// let val2 = ctx.getConstInt32(10)  // 1010 in binary
-/// let result = builder.createXor(val1, val2)  // 0110 in binary = 6
-/// inspect(result, content = "i32 6")
+/// let val1 = ctx.getConstInt32(12) // 1100 in binary
+/// let val2 = ctx.getConstInt32(10) // 1010 in binary
+/// let result = builder.createXor(val1, val2) // 0110 in binary = 6
+/// inspect(result, content="i32 6")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createXor(
@@ -1742,24 +1679,20 @@ pub fn IRBuilder::createNot(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "shl_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let shl_result = builder.createShl(arg1, arg2, name="result")
-/// inspect(shl_result, content = "  %result = shl i32 %0, %1")
+/// inspect(shl_result, content="  %result = shl i32 %0, %1")
 /// assert_true(shl_result.asValueEnum() is BinaryInst(_))
-///
-/// let val = ctx.getConstInt32(5)   // 101 in binary
+/// let val = ctx.getConstInt32(5) // 101 in binary
 /// let shift = ctx.getConstInt32(2) // shift left by 2
-/// let result = builder.createShl(val, shift)  // 10100 in binary = 20
-/// inspect(result, content = "i32 20")
+/// let result = builder.createShl(val, shift) // 10100 in binary = 20
+/// inspect(result, content="i32 20")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createShl(
@@ -1823,24 +1756,20 @@ pub fn IRBuilder::createShl(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "lshr_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let lshr_result = builder.createLShr(arg1, arg2, name="result")
-/// inspect(lshr_result, content = "  %result = lshr i32 %0, %1")
+/// inspect(lshr_result, content="  %result = lshr i32 %0, %1")
 /// assert_true(lshr_result.asValueEnum() is BinaryInst(_))
-///
-/// let twenty = ctx.getConstInt32(20)   // 10100 in binary
-/// let two = ctx.getConstInt32(2)       // shift right by 2
-/// let five = builder.createLShr(twenty, two)  // 101 in binary = 5
-/// inspect(five, content = "i32 5")
+/// let twenty = ctx.getConstInt32(20) // 10100 in binary
+/// let two = ctx.getConstInt32(2) // shift right by 2
+/// let five = builder.createLShr(twenty, two) // 101 in binary = 5
+/// inspect(five, content="i32 5")
 /// assert_true(five.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createLShr(
@@ -1900,24 +1829,20 @@ pub fn IRBuilder::createLShr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "ashr_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let ashr_result = builder.createAShr(arg1, arg2, name="result")
-/// inspect(ashr_result, content = "  %result = ashr i32 %0, %1")
+/// inspect(ashr_result, content="  %result = ashr i32 %0, %1")
 /// assert_true(ashr_result.asValueEnum() is BinaryInst(_))
-///
-/// let twenty = ctx.getConstInt32(20)   // 10100 in binary
-/// let two = ctx.getConstInt32(2)       // shift right by 2
-/// let five = builder.createAShr(twenty, two)  // 101 in binary = 5
-/// inspect(five, content = "i32 5")
+/// let twenty = ctx.getConstInt32(20) // 10100 in binary
+/// let two = ctx.getConstInt32(2) // shift right by 2
+/// let five = builder.createAShr(twenty, two) // 101 in binary = 5
+/// inspect(five, content="i32 5")
 /// assert_true(five.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createAShr(
@@ -1978,52 +1903,39 @@ pub fn IRBuilder::createAShr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let fval = mod.addFunction(fty, "icmp_demo")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg0 = fval.getArg(0).unwrap()
 /// let arg1 = fval.getArg(1).unwrap()
 /// builder.setInsertPoint(bb)
-///
 /// let eq_cmp = builder.createICmp(IntPredicate::EQ, arg0, arg1, name="eq_cmp")
-/// inspect(eq_cmp, content = "  %eq_cmp = icmp eq i32 %0, %1")
+/// inspect(eq_cmp, content="  %eq_cmp = icmp eq i32 %0, %1")
 /// assert_true(eq_cmp.asValueEnum() is ICmpInst(_))
-///
 /// let val1 = ctx.getConstInt32(5)
 /// let val2 = ctx.getConstInt32(5)
 /// let result = builder.createICmpEQ(val1, val2)
-/// inspect(result, content = "i1 true")
+/// inspect(result, content="i1 true")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
-///
 /// let ne_cmp = builder.createICmpNE(arg0, arg1, name="ne_cmp")
-/// inspect(ne_cmp, content = "  %ne_cmp = icmp ne i32 %0, %1")
-///
+/// inspect(ne_cmp, content="  %ne_cmp = icmp ne i32 %0, %1")
 /// let sgt_cmp = builder.createICmpSGT(arg0, arg1, name="sgt_cmp")
-/// inspect(sgt_cmp, content = "  %sgt_cmp = icmp sgt i32 %0, %1")
-///
+/// inspect(sgt_cmp, content="  %sgt_cmp = icmp sgt i32 %0, %1")
 /// let sge_cmp = builder.createICmpSGE(arg0, arg1, name="sge_cmp")
-/// inspect(sge_cmp, content = "  %sge_cmp = icmp sge i32 %0, %1")
-///
+/// inspect(sge_cmp, content="  %sge_cmp = icmp sge i32 %0, %1")
 /// let slt_cmp = builder.createICmpSLT(arg0, arg1, name="slt_cmp")
-/// inspect(slt_cmp, content = "  %slt_cmp = icmp slt i32 %0, %1")
-///
+/// inspect(slt_cmp, content="  %slt_cmp = icmp slt i32 %0, %1")
 /// let sle_cmp = builder.createICmpSLE(arg0, arg1, name="sle_cmp")
-/// inspect(sle_cmp, content = "  %sle_cmp = icmp sle i32 %0, %1")
-///
+/// inspect(sle_cmp, content="  %sle_cmp = icmp sle i32 %0, %1")
 /// let ugt_cmp = builder.createICmpUGT(arg0, arg1, name="ugt_cmp")
-/// inspect(ugt_cmp, content = "  %ugt_cmp = icmp ugt i32 %0, %1")
-///
+/// inspect(ugt_cmp, content="  %ugt_cmp = icmp ugt i32 %0, %1")
 /// let uge_cmp = builder.createICmpUGE(arg0, arg1, name="uge_cmp")
-/// inspect(uge_cmp, content = "  %uge_cmp = icmp uge i32 %0, %1")
-///
+/// inspect(uge_cmp, content="  %uge_cmp = icmp uge i32 %0, %1")
 /// let ult_cmp = builder.createICmpULT(arg0, arg1, name="ult_cmp")
-/// inspect(ult_cmp, content = "  %ult_cmp = icmp ult i32 %0, %1")
-///
+/// inspect(ult_cmp, content="  %ult_cmp = icmp ult i32 %0, %1")
 /// let ule_cmp = builder.createICmpULE(arg0, arg1, name="ule_cmp")
-/// inspect(ule_cmp, content = "  %ule_cmp = icmp ule i32 %0, %1")
+/// inspect(ule_cmp, content="  %ule_cmp = icmp ule i32 %0, %1")
 /// ```
 pub fn IRBuilder::createICmp(
   self : IRBuilder,
@@ -2202,61 +2114,50 @@ pub fn IRBuilder::createICmpSLE(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty, f32_ty])
 /// let fval = mod.addFunction(fty, "fcmp_demo")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg0 = fval.getArg(0).unwrap()
 /// let arg1 = fval.getArg(1).unwrap()
 /// builder.setInsertPoint(bb)
-///
-/// let oeq_cmp = builder.createFCmp(FloatPredicate::OEQ, arg0, arg1, name="oeq_cmp")
-/// inspect(oeq_cmp, content = "  %oeq_cmp = fcmp oeq float %0, %1")
+/// let oeq_cmp = builder.createFCmp(
+///   FloatPredicate::OEQ,
+///   arg0,
+///   arg1,
+///   name="oeq_cmp",
+/// )
+/// inspect(oeq_cmp, content="  %oeq_cmp = fcmp oeq float %0, %1")
 /// assert_true(oeq_cmp.asValueEnum() is FCmpInst(_))
-///
 /// let val1 = ctx.getConstFloat(3.14)
 /// let val2 = ctx.getConstFloat(3.14)
 /// let result = builder.createFCmpOEQ(val1, val2)
-/// inspect(result, content = "i1 true")
+/// inspect(result, content="i1 true")
 /// assert_true(result.asValueEnum() is ConstantInt(_))
-///
 /// let ogt_cmp = builder.createFCmpOGT(arg0, arg1, name="ogt_cmp")
-/// inspect(ogt_cmp, content = "  %ogt_cmp = fcmp ogt float %0, %1")
-///
+/// inspect(ogt_cmp, content="  %ogt_cmp = fcmp ogt float %0, %1")
 /// let oge_cmp = builder.createFCmpOGE(arg0, arg1, name="oge_cmp")
-/// inspect(oge_cmp, content = "  %oge_cmp = fcmp oge float %0, %1")
-///
+/// inspect(oge_cmp, content="  %oge_cmp = fcmp oge float %0, %1")
 /// let olt_cmp = builder.createFCmpOLT(arg0, arg1, name="olt_cmp")
-/// inspect(olt_cmp, content = "  %olt_cmp = fcmp olt float %0, %1")
-///
+/// inspect(olt_cmp, content="  %olt_cmp = fcmp olt float %0, %1")
 /// let ole_cmp = builder.createFCmpOLE(arg0, arg1, name="ole_cmp")
-/// inspect(ole_cmp, content = "  %ole_cmp = fcmp ole float %0, %1")
-///
+/// inspect(ole_cmp, content="  %ole_cmp = fcmp ole float %0, %1")
 /// let one_cmp = builder.createFCmpONE(arg0, arg1, name="one_cmp")
-/// inspect(one_cmp, content = "  %one_cmp = fcmp one float %0, %1")
-///
+/// inspect(one_cmp, content="  %one_cmp = fcmp one float %0, %1")
 /// let ord_cmp = builder.createFCmpORD(arg0, arg1, name="ord_cmp")
-/// inspect(ord_cmp, content = "  %ord_cmp = fcmp ord float %0, %1")
-///
+/// inspect(ord_cmp, content="  %ord_cmp = fcmp ord float %0, %1")
 /// let ueq_cmp = builder.createFCmpUEQ(arg0, arg1, name="ueq_cmp")
-/// inspect(ueq_cmp, content = "  %ueq_cmp = fcmp ueq float %0, %1")
-///
+/// inspect(ueq_cmp, content="  %ueq_cmp = fcmp ueq float %0, %1")
 /// let ugt_cmp = builder.createFCmpUGT(arg0, arg1, name="ugt_cmp")
-/// inspect(ugt_cmp, content = "  %ugt_cmp = fcmp ugt float %0, %1")
-///
+/// inspect(ugt_cmp, content="  %ugt_cmp = fcmp ugt float %0, %1")
 /// let uge_cmp = builder.createFCmpUGE(arg0, arg1, name="uge_cmp")
-/// inspect(uge_cmp, content = "  %uge_cmp = fcmp uge float %0, %1")
-///
+/// inspect(uge_cmp, content="  %uge_cmp = fcmp uge float %0, %1")
 /// let ult_cmp = builder.createFCmpULT(arg0, arg1, name="ult_cmp")
-/// inspect(ult_cmp, content = "  %ult_cmp = fcmp ult float %0, %1")
-///
+/// inspect(ult_cmp, content="  %ult_cmp = fcmp ult float %0, %1")
 /// let ule_cmp = builder.createFCmpULE(arg0, arg1, name="ule_cmp")
-/// inspect(ule_cmp, content = "  %ule_cmp = fcmp ule float %0, %1")
-///
+/// inspect(ule_cmp, content="  %ule_cmp = fcmp ule float %0, %1")
 /// let une_cmp = builder.createFCmpUNE(arg0, arg1, name="une_cmp")
-/// inspect(une_cmp, content = "  %une_cmp = fcmp une float %0, %1")
+/// inspect(une_cmp, content="  %une_cmp = fcmp une float %0, %1")
 /// ```
 pub fn IRBuilder::createFCmp(
   self : IRBuilder,
@@ -2487,23 +2388,19 @@ pub fn IRBuilder::createFCmpUNE(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i64_ty = ctx.getInt64Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "trunc_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let trunc = builder.createTrunc(arg, i32_ty, name="truncated")
-/// inspect(trunc, content = "  %truncated = trunc i64 %0 to i32")
+/// inspect(trunc, content="  %truncated = trunc i64 %0 to i32")
 /// assert_true(trunc.asValueEnum() is CastInst(_))
-///
 /// let big_val = ctx.getConstInt64(0x123456789L)
 /// let small_val = builder.createTrunc(big_val, i32_ty)
-/// inspect(small_val, content = "i32 591751049")
+/// inspect(small_val, content="i32 591751049")
 /// assert_true(small_val.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createTrunc(
@@ -2550,23 +2447,19 @@ pub fn IRBuilder::createTrunc(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let fty = ctx.getFunctionType(i64_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "zext_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let zext = builder.createZExt(arg, i64_ty, name="extended")
-/// inspect(zext, content = "  %extended = zext i32 %0 to i64")
+/// inspect(zext, content="  %extended = zext i32 %0 to i64")
 /// assert_true(zext.asValueEnum() is CastInst(_))
-///
 /// let small_val = ctx.getConstInt32(42)
 /// let big_val = builder.createZExt(small_val, i64_ty)
-/// inspect(big_val, content = "i64 42")
+/// inspect(big_val, content="i64 42")
 /// assert_true(big_val.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createZExt(
@@ -2613,23 +2506,19 @@ pub fn IRBuilder::createZExt(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let fty = ctx.getFunctionType(i64_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "sext_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let sext = builder.createSExt(arg, i64_ty, name="extended")
-/// inspect(sext, content = "  %extended = sext i32 %0 to i64")
+/// inspect(sext, content="  %extended = sext i32 %0 to i64")
 /// assert_true(sext.asValueEnum() is CastInst(_))
-///
 /// let small_val = ctx.getConstInt32(-42)
 /// let big_val = builder.createSExt(small_val, i64_ty)
-/// inspect(big_val, content = "i64 -42")
+/// inspect(big_val, content="i64 -42")
 /// assert_true(big_val.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createSExt(
@@ -2676,20 +2565,16 @@ pub fn IRBuilder::createSExt(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f64_ty = ctx.getDoubleTy()
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f64_ty])
-///
 /// let fval = mod.addFunction(fty, "fptrunc_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let fptrunc = builder.createFPTrunc(arg, f32_ty, name="truncated")
-/// inspect(fptrunc, content = "  %truncated = fptrunc double %0 to float")
+/// inspect(fptrunc, content="  %truncated = fptrunc double %0 to float")
 /// assert_true(fptrunc.asValueEnum() is CastInst(_))
-///
 /// let big_val = ctx.getConstDouble(3.14159)
 /// let small_val = builder.createFPTrunc(big_val, f32_ty)
 /// assert_true(small_val.asValueEnum() is ConstantFP(_))
@@ -2738,19 +2623,15 @@ pub fn IRBuilder::createFPTrunc(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let f64_ty = ctx.getDoubleTy()
 /// let fty = ctx.getFunctionType(f64_ty, [f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fpext_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let fpext = builder.createFPExt(arg, f64_ty, name="extended")
-///
-/// inspect(fpext, content = "  %extended = fpext float %0 to double")
+/// inspect(fpext, content="  %extended = fpext float %0 to double")
 /// ```
 pub fn IRBuilder::createFPExt(
   self : IRBuilder,
@@ -2796,20 +2677,16 @@ pub fn IRBuilder::createFPExt(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "uitofp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let uitofp = builder.createUIToFP(arg, f32_ty, name="converted")
-/// inspect(uitofp, content = "  %converted = uitofp i32 %0 to float")
+/// inspect(uitofp, content="  %converted = uitofp i32 %0 to float")
 /// assert_true(uitofp.asValueEnum() is CastInst(_))
-///
 /// let int_val = ctx.getConstInt32(42)
 /// let float_val = builder.createUIToFP(int_val, f32_ty)
 /// assert_true(float_val.asValueEnum() is ConstantFP(_))
@@ -2852,23 +2729,19 @@ pub fn IRBuilder::createUIToFP(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fptoui_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let fptoui = builder.createFPToUI(arg, i32_ty, name="converted")
-/// inspect(fptoui, content = "  %converted = fptoui float %0 to i32")
+/// inspect(fptoui, content="  %converted = fptoui float %0 to i32")
 /// assert_true(fptoui.asValueEnum() is CastInst(_))
-///
 /// let float_val = ctx.getConstFloat(3.14)
 /// let int_val = builder.createFPToUI(float_val, i32_ty)
-/// inspect(int_val, content = "i32 3")
+/// inspect(int_val, content="i32 3")
 /// assert_true(int_val.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createFPToUI(
@@ -2909,19 +2782,15 @@ pub fn IRBuilder::createFPToUI(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "sitofp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let sitofp = builder.createSIToFP(arg, f32_ty, name="converted")
-///
-/// inspect(sitofp, content = "  %converted = sitofp i32 %0 to float")
+/// inspect(sitofp, content="  %converted = sitofp i32 %0 to float")
 /// ```
 pub fn IRBuilder::createSIToFP(
   self : IRBuilder,
@@ -2961,19 +2830,15 @@ pub fn IRBuilder::createSIToFP(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fptosi_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let fptosi = builder.createFPToSI(arg, i32_ty, name="converted")
-///
-/// inspect(fptosi, content = "  %converted = fptosi float %0 to i32")
+/// inspect(fptosi, content="  %converted = fptosi float %0 to i32")
 /// ```
 pub fn IRBuilder::createFPToSI(
   self : IRBuilder,
@@ -3013,19 +2878,15 @@ pub fn IRBuilder::createFPToSI(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i64_ty = ctx.getInt64Ty()
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ptr_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "inttoptr_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let inttoptr = builder.createIntToPtr(arg, name="ptr")
-///
-/// inspect(inttoptr, content = "  %ptr = inttoptr i64 %0 to ptr")
+/// inspect(inttoptr, content="  %ptr = inttoptr i64 %0 to ptr")
 /// ```
 pub fn IRBuilder::createIntToPtr(
   self : IRBuilder,
@@ -3064,19 +2925,15 @@ pub fn IRBuilder::createIntToPtr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i64_ty = ctx.getInt64Ty()
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(i64_ty, [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "ptrtoint_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let ptrtoint = builder.createPtrToInt(arg, i64_ty, name="int_val")
-///
-/// inspect(ptrtoint, content = "  %int_val = ptrtoint ptr %0 to i64")
+/// inspect(ptrtoint, content="  %int_val = ptrtoint ptr %0 to i64")
 /// ```
 pub fn IRBuilder::createPtrToInt(
   self : IRBuilder,
@@ -3113,19 +2970,15 @@ pub fn IRBuilder::createPtrToInt(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "bitcast_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let bitcast = builder.createBitCast(arg, f32_ty, name="bits")
-///
-/// inspect(bitcast, content = "  %bits = bitcast i32 %0 to float")
+/// inspect(bitcast, content="  %bits = bitcast i32 %0 to float")
 /// ```
 pub fn IRBuilder::createBitCast(
   self : IRBuilder,
@@ -3180,22 +3033,27 @@ pub fn IRBuilder::createBitCast(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let array_ty = ctx.getArrayType(i32_ty, 10)
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ctx.getPtrTy(), [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "gep_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
 /// let zero = ctx.getConstInt32(0)
 /// let two = ctx.getConstInt32(2)
-///
 /// builder.setInsertPoint(bb)
-/// let gep = builder.createGEP(arg, array_ty, [zero, two], name="elem_ptr", inbounds=true)
-///
-/// inspect(gep, content = "  %elem_ptr = getelementptr inbounds [10 x i32], ptr %0, i32 0, i32 2")
+/// let gep = builder.createGEP(
+///   arg,
+///   array_ty,
+///   [zero, two],
+///   name="elem_ptr",
+///   inbounds=true,
+/// )
+/// inspect(
+///   gep,
+///   content="  %elem_ptr = getelementptr inbounds [10 x i32], ptr %0, i32 0, i32 2",
+/// )
 /// ```
 pub fn IRBuilder::createGEP(
   self : IRBuilder,
@@ -3253,18 +3111,14 @@ pub fn IRBuilder::createGEP(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(ctx.getVoidTy(), [])
-///
 /// let fval = mod.addFunction(fty, "load_demo")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let alloca = builder.createAlloca(i32_ty, name="temp")
 /// let load = builder.createLoad(i32_ty, alloca, name="val")
-///
-/// inspect(load, content = "  %val = load i32, ptr %temp, align 4")
+/// inspect(load, content="  %val = load i32, ptr %temp, align 4")
 /// ```
 pub fn IRBuilder::createLoad(
   self : IRBuilder,
@@ -3319,19 +3173,15 @@ pub fn IRBuilder::createLoad(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(ctx.getVoidTy(), [])
-///
 /// let fval = mod.addFunction(fty, "store_demo")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let alloca = builder.createAlloca(i32_ty, name="temp")
 /// let const_val = ctx.getConstInt32(42)
 /// let store = builder.createStore(const_val, alloca)
-///
-/// inspect(store, content = "  store i32 42, ptr %temp, align 4")
+/// inspect(store, content="  store i32 42, ptr %temp, align 4")
 /// ```
 pub fn IRBuilder::createStore(
   self : IRBuilder,
@@ -3369,18 +3219,14 @@ pub fn IRBuilder::createStore(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "br_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let target_bb = fval.addBasicBlock(name="target")
-///
 /// builder.setInsertPoint(entry_bb)
 /// let br = builder.createBr(target_bb)
-///
-/// inspect(br, content = "  br label %target")
+/// inspect(br, content="  br label %target")
 /// ```
 pub fn IRBuilder::createBr(
   self : Self,
@@ -3406,21 +3252,17 @@ pub fn IRBuilder::createBr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i1_ty])
-///
 /// let fval = mod.addFunction(fty, "cond_br_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let true_bb = fval.addBasicBlock(name="true_branch")
 /// let false_bb = fval.addBasicBlock(name="false_branch")
 /// let cond = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let cond_br = builder.createCondBr(cond, true_bb, false_bb)
-///
-/// inspect(cond_br, content = "  br i1 %0, label %true_branch, label %false_branch")
+/// inspect(cond_br, content="  br i1 %0, label %true_branch, label %false_branch")
 /// ```
 pub fn IRBuilder::createCondBr(
   self : Self,
@@ -3455,21 +3297,17 @@ pub fn IRBuilder::createCondBr(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i1_ty, i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "select_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let cond = fval.getArg(0).unwrap()
 /// let true_val = fval.getArg(1).unwrap()
 /// let false_val = fval.getArg(2).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let select = builder.createSelect(cond, true_val, false_val, name="result")
-///
-/// inspect(select, content = "  %result = select i1 %0, i32 %1, i32 %2")
+/// inspect(select, content="  %result = select i1 %0, i32 %1, i32 %2")
 /// ```
 pub fn IRBuilder::createSelect(
   self : IRBuilder,
@@ -3529,28 +3367,23 @@ pub fn IRBuilder::createSelect(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "switch_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let case1_bb = fval.addBasicBlock(name="case1")
 /// let default_bb = fval.addBasicBlock(name="default")
 /// let value = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let switch = builder.createSwitch(value, default_bb)
 /// let case_val = ctx.getConstInt32(42)
 /// switch.addCase(case_val, case1_bb)
-///
-/// let expect = 
+/// let expect =
 ///   #|  switch i32 %0, label %default [
 ///   #|    i32 42, label %case1
 ///   #|  ]
-///
-/// inspect(switch, content = expect)
+/// inspect(switch, content=expect)
 /// ```
 pub fn IRBuilder::createSwitch(
   self : IRBuilder,
@@ -3584,23 +3417,19 @@ pub fn IRBuilder::createSwitch(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block_bb = fval.addBasicBlock(name="block")
 /// let merge_bb = fval.addBasicBlock(name="merge")
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block_bb)
-///
-/// inspect(phi, content = "  %result = phi i32 [ 10, %entry ], [ 20, %block ]")
+/// inspect(phi, content="  %result = phi i32 [ 10, %entry ], [ 20, %block ]")
 /// ```
 pub fn IRBuilder::createPHI(
   self : IRBuilder,
@@ -3629,21 +3458,17 @@ pub fn IRBuilder::createPHI(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let add_fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let main_fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let add_func = mod.addFunction(add_fty, "add")
 /// let main_func = mod.addFunction(main_fty, "main")
 /// let bb = main_func.addBasicBlock(name="entry")
 /// let arg1 = ctx.getConstInt32(10)
 /// let arg2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(bb)
 /// let call = builder.createCall(add_func, [arg1, arg2], name="sum")
-///
-/// inspect(call, content = "  %sum = call i32 @add(i32 10, i32 20)")
+/// inspect(call, content="  %sum = call i32 @add(i32 10, i32 20)")
 /// ```
 pub fn IRBuilder::createCall(
   self : IRBuilder,

--- a/IR/IRBuilder.mbt
+++ b/IR/IRBuilder.mbt
@@ -92,7 +92,7 @@ pub fn IRBuilder::getModule(self : IRBuilder) -> Module {
 /// 
 /// `IRBuilder::createRet` could not return void. use `IRBuilder::createRetVoid` for that purpose.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -135,7 +135,7 @@ pub fn IRBuilder::createRet(
 ///
 /// If you want to return a value, use `IRBuilder::createRet` instead.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -167,7 +167,7 @@ pub fn IRBuilder::createRetVoid(self : IRBuilder) -> &Instruction raise Error {
 ///|
 /// Create an Alloca Instruction.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -211,7 +211,7 @@ pub fn IRBuilder::createAlloca(
 /// 
 /// This creates an integer addition instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -291,7 +291,7 @@ pub fn IRBuilder::createAdd(
 /// 
 /// This creates an integer addition instruction with No Signed Wrap (NSW) flag. If signed overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -331,7 +331,7 @@ pub fn IRBuilder::createNSWAdd(
 /// 
 /// This creates an integer addition instruction with No Unsigned Wrap (NUW) flag. If unsigned overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -371,7 +371,7 @@ pub fn IRBuilder::createNUWAdd(
 /// 
 /// This creates an integer subtraction instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -451,7 +451,7 @@ pub fn IRBuilder::createSub(
 /// 
 /// This creates an integer subtraction instruction with No Signed Wrap (NSW) flag. If signed overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -491,7 +491,7 @@ pub fn IRBuilder::createNSWSub(
 /// 
 /// This creates an integer subtraction instruction with No Unsigned Wrap (NUW) flag. If unsigned overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -542,7 +542,7 @@ pub fn IRBuilder::createNeg(
 /// 
 /// This creates an integer multiplication instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -622,7 +622,7 @@ pub fn IRBuilder::createMul(
 /// 
 /// This creates an integer multiplication instruction with No Signed Wrap (NSW) flag. If signed overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -662,7 +662,7 @@ pub fn IRBuilder::createNSWMul(
 /// 
 /// This creates an integer multiplication instruction with No Unsigned Wrap (NUW) flag. If unsigned overflow occurs, the result is undefined.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -703,7 +703,7 @@ pub fn IRBuilder::createNUWMul(
 /// This creates a signed integer division instruction.
 /// Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -724,7 +724,7 @@ pub fn IRBuilder::createNUWMul(
 /// let twelve = ctx.getConstInt32(12)
 /// let three = ctx.getConstInt32(3)
 /// let four = builder.createSDiv(twelve, three)
-/// inspect(four, content = "i32 4")
+/// inspect(four, content = "  %2 = sdiv i32 12, 3")
 /// assert_true(four.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createSDiv(
@@ -781,7 +781,7 @@ pub fn IRBuilder::createSDiv(
 /// This creates an exact signed integer division instruction. Both operands must be integer types with the same bitwidth.
 /// The exact flag indicates that the division is expected to be exact (no remainder).
 ///
-/// ```moonbit skip
+/// ```mbt
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -802,7 +802,7 @@ pub fn IRBuilder::createSDiv(
 /// let twelve = ctx.getConstInt32(12)
 /// let three = ctx.getConstInt32(3)
 /// let four = builder.createExactSDiv(twelve, three)
-/// inspect(four, content = "i32 4")
+/// inspect(four, content = "  %2 = sdiv exact i32 12, 3")
 /// assert_true(four.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createExactSDiv(
@@ -822,7 +822,7 @@ pub fn IRBuilder::createExactSDiv(
 /// This creates an unsigned integer division instruction. 
 /// Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -843,7 +843,7 @@ pub fn IRBuilder::createExactSDiv(
 /// let twelve = ctx.getConstInt32(12)
 /// let three = ctx.getConstInt32(3)
 /// let four = builder.createUDiv(twelve, three)
-/// inspect(four, content = "i32 4")
+/// inspect(four, content = "  %2 = udiv i32 12, 3")
 /// assert_true(four.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createUDiv(
@@ -900,7 +900,7 @@ pub fn IRBuilder::createUDiv(
 /// Both operands must be integer types with the same bitwidth.
 /// The exact flag indicates that the division is expected to be exact (no remainder).
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -921,7 +921,7 @@ pub fn IRBuilder::createUDiv(
 /// let twelve = ctx.getConstInt32(12)
 /// let three = ctx.getConstInt32(3)
 /// let four = builder.createExactUDiv(twelve, three)
-/// inspect(four, content = "i32 4")
+/// inspect(four, content = "  %2 = udiv exact i32 12, 3")
 /// assert_true(four.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createExactUDiv(
@@ -940,7 +940,7 @@ pub fn IRBuilder::createExactUDiv(
 /// 
 /// This creates a signed integer remainder instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -961,7 +961,7 @@ pub fn IRBuilder::createExactUDiv(
 /// let thirteen = ctx.getConstInt32(13)
 /// let five = ctx.getConstInt32(5)
 /// let three = builder.createSRem(thirteen, five)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content = "  %2 = srem i32 13, 5")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createSRem(
@@ -1014,7 +1014,7 @@ pub fn IRBuilder::createSRem(
 /// 
 /// This creates an unsigned integer remainder instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1035,7 +1035,7 @@ pub fn IRBuilder::createSRem(
 /// let thirteen = ctx.getConstInt32(13)
 /// let five = ctx.getConstInt32(5)
 /// let three = builder.createURem(thirteen, five)
-/// inspect(three, content = "i32 3")
+/// inspect(three, content = "  %2 = urem i32 13, 5")
 /// assert_true(three.asValueEnum() is ConstantInt(_))
 /// ```
 pub fn IRBuilder::createURem(
@@ -1100,7 +1100,7 @@ pub fn IRBuilder::createURem(
 /// 6. `AllowReciprocal`
 /// 7. `ApproxFunc`
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1121,7 +1121,7 @@ pub fn IRBuilder::createURem(
 /// let one = ctx.getConstFloat(1.0)
 /// let two = ctx.getConstFloat(2.0)
 /// let three = builder.createFAdd(one, two)
-/// inspect(three, content = "float 3.000000e+00")
+/// inspect(three, content = "  %2 = fadd float 0x3FF0000000000000, 0x4000000000000000")
 /// assert_true(three.asValueEnum() is ConstantFP(_))
 ///
 /// let nnan_fadd = builder.createFAdd(arg1, arg2, name="sum_nnan", fast_math=[NoNaNs])
@@ -1180,7 +1180,7 @@ pub fn IRBuilder::createFAdd(
 /// 
 /// This creates a floating-point subtraction instruction. Both operands must be floating-point types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1201,7 +1201,7 @@ pub fn IRBuilder::createFAdd(
 /// let five = ctx.getConstFloat(5.0)
 /// let two = ctx.getConstFloat(2.0)
 /// let three = builder.createFSub(five, two)
-/// inspect(three, content = "float 3.000000e+00")
+/// inspect(three, content = "  %2 = fsub float 0x4014000000000000, 0x4000000000000000")
 /// assert_true(three.asValueEnum() is ConstantFP(_))
 /// ```
 pub fn IRBuilder::createFSub(
@@ -1248,7 +1248,7 @@ pub fn IRBuilder::createFSub(
 ///
 /// This creates a floating-point negation instruction. The operand must be a floating-point type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1295,7 +1295,7 @@ pub fn IRBuilder::createFNeg(
 /// 
 /// This creates a floating-point multiplication instruction. Both operands must be floating-point types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1316,7 +1316,7 @@ pub fn IRBuilder::createFNeg(
 /// let three = ctx.getConstFloat(3.0)
 /// let four = ctx.getConstFloat(4.0)
 /// let twelve = builder.createFMul(three, four)
-/// inspect(twelve, content = "float 1.200000e+01")
+/// inspect(twelve, content = "  %2 = fmul float 0x4008000000000000, 0x4010000000000000")
 /// assert_true(twelve.asValueEnum() is ConstantFP(_))
 /// ```
 pub fn IRBuilder::createFMul(
@@ -1363,7 +1363,7 @@ pub fn IRBuilder::createFMul(
 /// 
 /// This creates a floating-point division instruction. Both operands must be floating-point types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1384,7 +1384,7 @@ pub fn IRBuilder::createFMul(
 /// let eight = ctx.getConstFloat(8.0)
 /// let two = ctx.getConstFloat(2.0)
 /// let four = builder.createFDiv(eight, two)
-/// inspect(four, content = "float 4.000000e+00")
+/// inspect(four, content = "  %2 = fdiv float 0x4020000000000000, 0x4000000000000000")
 /// assert_true(four.asValueEnum() is ConstantFP(_))
 /// ```
 pub fn IRBuilder::createFDiv(
@@ -1431,7 +1431,7 @@ pub fn IRBuilder::createFDiv(
 /// 
 /// This creates a floating-point remainder instruction. Both operands must be floating-point types with the same bitwidth.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1452,7 +1452,7 @@ pub fn IRBuilder::createFDiv(
 /// let five_and_half = ctx.getConstFloat(5.5)
 /// let two = ctx.getConstFloat(2.0)
 /// let one_and_half = builder.createFRem(five_and_half, two)
-/// inspect(one_and_half, content = "float 1.500000e+00")
+/// inspect(one_and_half, content = "  %2 = frem float 0x4016000000000000, 0x4000000000000000")
 /// assert_true(one_and_half.asValueEnum() is ConstantFP(_))
 /// ```
 pub fn IRBuilder::createFRem(
@@ -1499,7 +1499,7 @@ pub fn IRBuilder::createFRem(
 /// 
 /// This creates a bitwise AND instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1571,7 +1571,7 @@ pub fn IRBuilder::createAnd(
 /// 
 /// This creates a bitwise OR instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1643,7 +1643,7 @@ pub fn IRBuilder::createOr(
 /// 
 /// This creates a bitwise XOR instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1738,7 +1738,7 @@ pub fn IRBuilder::createNot(
 /// 
 /// This creates a left shift instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1819,7 +1819,7 @@ pub fn IRBuilder::createShl(
 /// 
 /// This creates a logical right shift instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1896,7 +1896,7 @@ pub fn IRBuilder::createLShr(
 /// 
 /// This creates an arithmetic right shift instruction. Both operands must be integer types with the same bitwidth.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1974,7 +1974,7 @@ pub fn IRBuilder::createAShr(
 /// 1. `lhs` and `rhs` must be integer types with the same bitwidth.
 /// 2. Allowed predicates: EQ, NE, SGT, SGE, SLT, SLE, UGT, UGE, ULT, ULE.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2198,7 +2198,7 @@ pub fn IRBuilder::createICmpSLE(
 /// 1. `lhs` and `rhs` must be floating-point types with the same bitwidth.
 /// 2. Allowed predicates: OEQ, OGT, OGE, OLT, OLE, ONE, ORD, UEQ, UGT, UGE, ULT, ULE, UNE.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2483,7 +2483,7 @@ pub fn IRBuilder::createFCmpUNE(
 /// This creates a truncation instruction that truncates an integer value to a smaller integer type.
 /// The input value must be an integer type, and the target type must be a smaller integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2546,7 +2546,7 @@ pub fn IRBuilder::createTrunc(
 /// This creates a zero extension instruction that extends an integer value to a larger integer type by padding with zeros.
 /// The input value must be an integer type, and the target type must be a larger integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2609,7 +2609,7 @@ pub fn IRBuilder::createZExt(
 /// This creates a sign extension instruction that extends an integer value to a larger integer type by replicating the sign bit.
 /// The input value must be an integer type, and the target type must be a larger integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2672,7 +2672,7 @@ pub fn IRBuilder::createSExt(
 /// This creates a floating-point truncation instruction that truncates a floating-point value to a smaller floating-point type.
 /// The input value must be a floating-point type, and the target type must be a smaller floating-point type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2734,7 +2734,7 @@ pub fn IRBuilder::createFPTrunc(
 /// This creates a floating-point extension instruction that extends a floating-point value to a larger floating-point type.
 /// The input value must be a floating-point type, and the target type must be a larger floating-point type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2792,7 +2792,7 @@ pub fn IRBuilder::createFPExt(
 /// This creates an unsigned integer to floating-point conversion instruction that converts an unsigned integer value to a floating-point value.
 /// The input value must be an integer type, and the target type must be a floating-point type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2848,7 +2848,7 @@ pub fn IRBuilder::createUIToFP(
 /// This creates a floating-point to unsigned integer conversion instruction that converts a floating-point value to an unsigned integer.
 /// The input value must be a floating-point type, and the target type must be an integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2905,7 +2905,7 @@ pub fn IRBuilder::createFPToUI(
 /// This creates a signed integer to floating-point conversion instruction that converts a signed integer value to a floating-point value.
 /// The input value must be an integer type, and the target type must be a floating-point type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2957,7 +2957,7 @@ pub fn IRBuilder::createSIToFP(
 /// This creates a floating-point to signed integer conversion instruction that converts a floating-point value to a signed integer.
 /// The input value must be a floating-point type, and the target type must be an integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3009,7 +3009,7 @@ pub fn IRBuilder::createFPToSI(
 /// This creates an integer to pointer conversion instruction that converts an integer value to a pointer.
 /// The input value must be an integer type, and the target type must be a pointer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3060,7 +3060,7 @@ pub fn IRBuilder::createIntToPtr(
 /// This creates a pointer to integer conversion instruction that converts a pointer value to an integer.
 /// The input value must be a pointer type, and the target type must be an integer type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3109,7 +3109,7 @@ pub fn IRBuilder::createPtrToInt(
 /// This creates a bitcast instruction that converts a value from one type to another without changing the bit representation.
 /// The source and destination types must have the same bit width.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3176,7 +3176,7 @@ pub fn IRBuilder::createBitCast(
 /// The pointer must be a pointer type, and all indices must be integer values.
 /// When inbounds is true, the result is undefined if the computed address is outside the bounds of the allocated object.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3249,7 +3249,7 @@ pub fn IRBuilder::createGEP(
 /// 
 /// This loads a value from memory at the specified pointer.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3315,7 +3315,7 @@ pub fn IRBuilder::createLoad(
 /// 
 /// This stores a value into memory at the specified pointer.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3365,7 +3365,7 @@ pub fn IRBuilder::createStore(
 /// This creates an unconditional branch instruction that transfers control to the specified basic block.
 /// The destination must be a valid basic block.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3402,7 +3402,7 @@ pub fn IRBuilder::createBr(
 /// This creates a conditional branch instruction that transfers control to one of two basic blocks based on a boolean condition.
 /// The condition must be an i1 (boolean) type, and both destinations must be valid basic blocks.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3451,7 +3451,7 @@ pub fn IRBuilder::createCondBr(
 /// This creates a select instruction that chooses between two values based on a boolean condition.
 /// The condition must be an i1 (boolean) type, and both values must have the same type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3525,7 +3525,7 @@ pub fn IRBuilder::createSelect(
 /// The value must be an integer type, and numCases specifies the expected number of cases.
 /// Use `SwitchInst::addCase` to add individual cases after creation.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3580,7 +3580,7 @@ pub fn IRBuilder::createSwitch(
 /// The type specifies the type of the PHI node's result value.
 /// Use `PHINode::addIncoming` to add incoming values and their corresponding basic blocks.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3625,7 +3625,7 @@ pub fn IRBuilder::createPHI(
 /// This creates a call instruction that invokes a function with the specified arguments.
 /// The function must be a valid Function object, and the arguments must match the function's parameter types.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3778,7 +3778,7 @@ pub fn IRBuilder::createCallPtr(
 /// This creates an extractvalue instruction that extracts a value from an aggregate (struct or array) at the specified index.
 /// The aggregate must be an aggregate type, and the index must be valid for the aggregate type.
 ///
-/// ```moonbit skip
+/// ```mbt
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3838,7 +3838,7 @@ pub fn IRBuilder::createExtractValue(
 /// This creates an insertvalue instruction that inserts a value into an aggregate (struct or array) at the specified index.
 /// The aggregate must be an aggregate type, and the value type must match the element type at the given index.
 ///
-/// ```moonbit skip
+/// ```mbt
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3909,7 +3909,7 @@ pub fn IRBuilder::createGlobalString(
 /// This creates a malloc instruction that allocates memory for a single instance of the specified type.
 /// The type must not be an abstract type. The result is a pointer to the allocated memory.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3940,7 +3940,7 @@ pub fn IRBuilder::createGlobalString(
 /// This creates a free instruction that deallocates memory previously allocated by malloc.
 /// The pointer must be a pointer type and should point to memory allocated by malloc.
 ///
-/// ```moonbit skip
+/// ```mbt skip
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()

--- a/IR/Instruction.mbt
+++ b/IR/Instruction.mbt
@@ -9,7 +9,7 @@
 /// 
 /// Use `IRBuilder::createAlloca` to create an `AllocaInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -76,7 +76,7 @@ pub impl Value for AllocaInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -115,7 +115,7 @@ pub impl Value for AllocaInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -146,7 +146,7 @@ pub impl Value for AllocaInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -275,7 +275,7 @@ pub impl Show for AtomicOrdering with output(self, logger) {
 ///
 /// Use `IRBuilder::createLoad` to create a `LoadInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -374,7 +374,7 @@ pub impl Value for LoadInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -410,7 +410,7 @@ pub impl Value for LoadInst with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -443,7 +443,7 @@ pub impl Value for LoadInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -571,7 +571,7 @@ pub impl Show for LoadInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createStore` to create a `StoreInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -657,7 +657,7 @@ fn StoreInst::new(
 ///|
 /// Get the value operand of the store instruction.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -690,7 +690,7 @@ pub fn StoreInst::getValueOperand(self : StoreInst) -> &Value {
 ///|
 /// Get the pointer operand of the store instruction.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1088,7 +1088,7 @@ pub impl Show for FastMathFlag with output(self, logger) {
 ///
 /// Use `IRBuilder::createAdd`, `IRBuilder::createSub`, `IRBuilder::createMul`, etc. to create binary instructions.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1263,7 +1263,7 @@ pub impl Value for BinaryInst with asValueEnum(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1300,7 +1300,7 @@ pub impl Value for BinaryInst with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1334,7 +1334,7 @@ pub impl Value for BinaryInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1504,7 +1504,7 @@ pub impl Show for IntPredicate with output(self, logger) {
 ///
 /// Use `IRBuilder::createICmp` to create an `ICmpInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1599,7 +1599,7 @@ pub impl Value for ICmpInst with asValueEnum(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1635,7 +1635,7 @@ pub impl Value for ICmpInst with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1668,7 +1668,7 @@ pub impl Value for ICmpInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1843,7 +1843,7 @@ pub impl Show for FloatPredicate with output(self, logger) {
 ///
 /// Use `IRBuilder::createFCmp` to create an `FCmpInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1929,7 +1929,7 @@ pub impl Value for FCmpInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -1970,7 +1970,7 @@ pub impl Value for FCmpInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2003,7 +2003,7 @@ pub impl Value for FCmpInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2156,7 +2156,7 @@ pub impl Show for CastOps with output(self, logger) {
 ///
 /// Use `IRBuilder::createTrunc`, `IRBuilder::createZExt`, `IRBuilder::createSExt`, etc. to create cast instructions.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2535,7 +2535,7 @@ pub impl Value for CastInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2576,7 +2576,7 @@ pub impl Value for CastInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2609,7 +2609,7 @@ pub impl Value for CastInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2730,7 +2730,7 @@ pub impl Show for CastInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createGEP` to create a `GetElementPtrInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2810,7 +2810,7 @@ pub impl Value for GetElementPtrInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2854,7 +2854,7 @@ pub impl Value for GetElementPtrInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -2890,7 +2890,7 @@ pub impl Value for GetElementPtrInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3017,7 +3017,7 @@ pub impl Show for GetElementPtrInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createSelect` to create a `SelectInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3109,7 +3109,7 @@ pub impl Value for SelectInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3152,7 +3152,7 @@ pub impl Value for SelectInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3187,7 +3187,7 @@ pub impl Value for SelectInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3310,7 +3310,7 @@ pub impl Show for SelectInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createRet` or `IRBuilder::createRetVoid` to create a `ReturnInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3453,7 +3453,7 @@ pub impl Show for ReturnInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createBr` for unconditional branches or `IRBuilder::createCondBr` for conditional branches.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3688,7 +3688,7 @@ pub impl Show for BranchInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createSwitch` to create a `SwitchInst`, then use `SwitchInst::addCase` to add individual cases.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3783,7 +3783,7 @@ pub fn SwitchInst::getNumCases(self : Self) -> Int {
 ///
 /// Returns `None` if the index is out of bounds. Use `SwitchInst::getNumCases` to get the total number of cases.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -3828,7 +3828,7 @@ pub fn SwitchInst::getCase(
 /// The case condition must be a constant integer with the same type as the switch condition.
 /// Will raise `LLVMValueError` if there is a type mismatch between the case condition and switch condition.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4003,7 +4003,7 @@ pub impl Show for SwitchInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createPHI` to create a `PHINode`, then use `PHINode::addIncoming` to add incoming values.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4056,7 +4056,7 @@ fn PHINode::new(vty : &Type, parent : Function, name~ : String?) -> PHINode {
 ///
 /// Returns the total count of incoming value-block pairs added to this PHI node.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4096,7 +4096,7 @@ pub fn PHINode::getNumIncomingValues(self : PHINode) -> Int {
 ///
 /// Returns `None` if the index is out of bounds. Use `PHINode::getNumIncomingValues` to get the valid range.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4134,7 +4134,7 @@ pub fn PHINode::getIncomingValue(self : PHINode, idx : Int) -> &Value? {
 ///
 /// Returns `None` if the index is out of bounds. Use `PHINode::getNumIncomingValues` to get the valid range.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4172,7 +4172,7 @@ pub fn PHINode::getIncomingBlock(self : PHINode, idx : Int) -> BasicBlock? {
 ///
 /// Returns `None` if the index is out of bounds. This is a convenience method that returns both the value and block together.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4213,7 +4213,7 @@ pub fn PHINode::getIncoming(self : PHINode, idx : Int) -> (&Value, BasicBlock)? 
 ///
 /// Returns a copy of the internal array containing all value-block pairs in the order they were added.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4254,7 +4254,7 @@ pub fn PHINode::getIncomings(self : PHINode) -> Array[(&Value, BasicBlock)] {
 ///
 /// Returns an array containing only the values from all incoming value-block pairs, in the order they were added.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4294,7 +4294,7 @@ pub fn PHINode::getIncomingValues(self : PHINode) -> Array[&Value] {
 ///
 /// Returns an array containing only the basic blocks from all incoming value-block pairs, in the order they were added.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4335,7 +4335,7 @@ pub fn PHINode::getIncomingBlocks(self : PHINode) -> Array[BasicBlock] {
 /// The value's type must match the PHI node's type. Will raise `LLVMValueError` if there is a type mismatch.
 /// The basic block represents the predecessor block from which this value flows into the PHI node.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4392,7 +4392,7 @@ pub impl Value for PHINode with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4426,7 +4426,7 @@ pub impl Value for PHINode with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4457,7 +4457,7 @@ pub impl Value for PHINode with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4606,7 +4606,7 @@ pub impl Show for TailCallKind with output(self, logger) {
 ///
 /// Use `IRBuilder::createCall` to create a `CallInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4780,7 +4780,7 @@ pub impl Value for CallInst with asValueEnum(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4821,7 +4821,7 @@ pub impl Value for CallInst with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -4871,7 +4871,7 @@ pub impl Value for CallInst with getNameOrSlot(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error. Cannot set name for CallInst with void return type.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5056,7 +5056,7 @@ pub impl Show for CallInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createExtractValue` to create an `ExtractValueInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5139,7 +5139,7 @@ pub impl Value for ExtractValueInst with getValueBase(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5180,7 +5180,7 @@ pub impl Value for ExtractValueInst with asValueEnum(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5213,7 +5213,7 @@ pub impl Value for ExtractValueInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5335,7 +5335,7 @@ pub impl Show for ExtractValueInst with output(self, logger) {
 ///
 /// Use `IRBuilder::createInsertValue` to create an `InsertValueInst`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5435,7 +5435,7 @@ pub impl Value for InsertValueInst with asValueEnum(self) {
 ///|
 /// Get simple representation of the value.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5472,7 +5472,7 @@ pub impl Value for InsertValueInst with getValueRepr(self) {
 ///
 /// If the instruction has no name, return `None`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
@@ -5506,7 +5506,7 @@ pub impl Value for InsertValueInst with getName(self) {
 /// If the name has already been used in the parent function,
 /// it will raise Error.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()

--- a/IR/Instruction.mbt
+++ b/IR/Instruction.mbt
@@ -13,18 +13,14 @@
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "foo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let inst = builder.createAlloca(i32_ty, name="var1")
-///
-/// inspect(inst, content = "  %var1 = alloca i32, align 4")
+/// inspect(inst, content="  %var1 = alloca i32, align 4")
 /// ```
 pub struct AllocaInst {
   uid : UInt64
@@ -80,20 +76,16 @@ pub impl Value for AllocaInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "foo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let inst = builder.createAlloca(i32_ty)
-/// inspect(inst.getValueRepr(), content = "%0")
-///
+/// inspect(inst.getValueRepr(), content="%0")
 /// inst.setName("var1")
-/// inspect(inst.getValueRepr(), content = "%var1")
+/// inspect(inst.getValueRepr(), content="%var1")
 /// ```
 pub impl Value for AllocaInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -119,20 +111,16 @@ pub impl Value for AllocaInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "foo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let inst = builder.createAlloca(i32_ty)
-/// inspect(inst.getName(), content = "None")
-///
+/// inspect(inst.getName(), content="None")
 /// inst.setName("var1")
-/// inspect(inst.getName(), content = "Some(\"var1\")")
+/// inspect(inst.getName(), content="Some(\"var1\")")
 /// ```
 pub impl Value for AllocaInst with getName(self) {
   self.name
@@ -150,20 +138,16 @@ pub impl Value for AllocaInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(void_ty, [])
-///
 /// let fval = mod.addFunction(fty, "foo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let inst = builder.createAlloca(i32_ty)
-/// inspect(inst.getName(), content = "None")
-///
+/// inspect(inst.getName(), content="None")
 /// inst.setName("var1")
-/// inspect(inst.getName(), content = "Some(\"var1\")")
+/// inspect(inst.getName(), content="Some(\"var1\")")
 /// ```
 pub impl Value for AllocaInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -279,22 +263,17 @@ pub impl Show for AtomicOrdering with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [ptr_ty])
 /// let fval = mod.addFunction(fty, "load_an_integer")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let ptr = fval.getArg(0).unwrap()
 /// ptr.setName("arg0")
-///
 /// let val = builder.createLoad(i32_ty, ptr, name="val")
 /// let _ = builder.createRet(val)
-/// inspect(val, content = "  %val = load i32, ptr %arg0, align 4")
+/// inspect(val, content="  %val = load i32, ptr %arg0, align 4")
 /// ```
 pub(all) struct LoadInst {
   // --- ValueBase ---
@@ -378,22 +357,17 @@ pub impl Value for LoadInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [ptr_ty])
 /// let fval = mod.addFunction(fty, "load_an_integer")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let ptr = fval.getArg(0).unwrap()
-///
 /// let val = builder.createLoad(i32_ty, ptr)
-/// inspect(val.getValueRepr(), content = "%1")
-///
+/// inspect(val.getValueRepr(), content="%1")
 /// val.setName("val")
-/// inspect(val.getValueRepr(), content = "%val")
+/// inspect(val.getValueRepr(), content="%val")
 /// ```
 pub impl Value for LoadInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -414,22 +388,17 @@ pub impl Value for LoadInst with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [ptr_ty])
 /// let fval = mod.addFunction(fty, "load_an_integer")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let ptr = fval.getArg(0).unwrap()
-///
 /// let val = builder.createLoad(i32_ty, ptr)
-/// inspect(val.getName(), content = "None")
-///
+/// inspect(val.getName(), content="None")
 /// val.setName("val")
-/// inspect(val.getName(), content = "Some(\"val\")")
+/// inspect(val.getName(), content="Some(\"val\")")
 /// ```
 pub impl Value for LoadInst with getName(self) {
   self.name
@@ -447,22 +416,17 @@ pub impl Value for LoadInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
-///
 /// let fty = ctx.getFunctionType(i32_ty, [ptr_ty])
 /// let fval = mod.addFunction(fty, "load_an_integer")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(bb)
 /// let ptr = fval.getArg(0).unwrap()
-///
 /// let val = builder.createLoad(i32_ty, ptr)
-/// inspect(val.getName(), content = "None")
-///
+/// inspect(val.getName(), content="None")
 /// val.setName("val")
-/// inspect(val.getName(), content = "Some(\"val\")")
+/// inspect(val.getName(), content="Some(\"val\")")
 /// ```
 pub impl Value for LoadInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -575,26 +539,19 @@ pub impl Show for LoadInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
-///
 /// let fty = ctx.getFunctionType(void_ty, [ptr_ty, i32_ty])
 /// let fval = mod.addFunction(fty, "store_an_integer")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let ptr = fval.getArg(0).unwrap()
 /// ptr.setName("arg0")
-///
 /// let value = fval.getArg(1).unwrap()
 /// value.setName("value")
-///
 /// let s = builder.createStore(value, ptr)
-///
-/// inspect(s, content = "  store i32 %value, ptr %arg0, align 4")
+/// inspect(s, content="  store i32 %value, ptr %arg0, align 4")
 /// ```
 pub struct StoreInst {
   // --- ValueBase ---
@@ -661,27 +618,20 @@ fn StoreInst::new(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let ptr_ty = ctx.getPtrTy()
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
-///
 /// let fty = ctx.getFunctionType(void_ty, [ptr_ty, i32_ty])
 /// let fval = mod.addFunction(fty, "store_an_integer")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let ptr = fval.getArg(0).unwrap()
 /// ptr.setName("arg0")
-///
 /// let val1 = fval.getArg(1).unwrap()
 /// let const_42 = ctx.getConstInt32(42)
 /// let val2 = builder.createNSWAdd(val1, const_42, name="value")
-///
 /// let s = builder.createStore(val2, ptr)
-///
-/// inspect(s.getValueOperand(), content = "  %value = add nsw i32 %0, 42")
+/// inspect(s.getValueOperand(), content="  %value = add nsw i32 %0, 42")
 /// ```
 pub fn StoreInst::getValueOperand(self : StoreInst) -> &Value {
   self.value
@@ -694,21 +644,15 @@ pub fn StoreInst::getValueOperand(self : StoreInst) -> &Value {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let void_ty = ctx.getVoidTy()
-///
 /// let fty = ctx.getFunctionType(void_ty, [])
 /// let fval = mod.addFunction(fty, "store_an_integer")
-///
 /// let bb = fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(bb)
-///
 /// let alloca = builder.createAlloca(ctx.getInt32Ty(), name="ptr")
 /// let const42 = ctx.getConstInt32(42)
-///
 /// let s = builder.createStore(const42, alloca)
-///
-/// inspect(s.getPointerOperand(), content = "  %ptr = alloca i32, align 4")
+/// inspect(s.getPointerOperand(), content="  %ptr = alloca i32, align 4")
 /// ```
 pub fn StoreInst::getPointerOperand(self : StoreInst) -> &Value {
   self.ptr
@@ -1092,35 +1036,26 @@ pub impl Show for FastMathFlag with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "binary_ops_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
-///
 /// let add = builder.createAdd(arg1, arg2, name="sum")
-/// inspect(add, content = "  %sum = add i32 %0, %1")
+/// inspect(add, content="  %sum = add i32 %0, %1")
 /// assert_true(add.asValueEnum() is BinaryInst(_))
-///
 /// let sub = builder.createSub(arg1, arg2, name="diff")
-/// inspect(sub, content = "  %diff = sub i32 %0, %1")
-///
+/// inspect(sub, content="  %diff = sub i32 %0, %1")
 /// let mul = builder.createMul(arg1, arg2, name="product")
-/// inspect(mul, content = "  %product = mul i32 %0, %1")
-///
+/// inspect(mul, content="  %product = mul i32 %0, %1")
 /// let and_result = builder.createAnd(arg1, arg2, name="and_result")
-/// inspect(and_result, content = "  %and_result = and i32 %0, %1")
-///
+/// inspect(and_result, content="  %and_result = and i32 %0, %1")
 /// let or_result = builder.createOr(arg1, arg2, name="or_result")
-/// inspect(or_result, content = "  %or_result = or i32 %0, %1")
-///
+/// inspect(or_result, content="  %or_result = or i32 %0, %1")
 /// let xor_result = builder.createXor(arg1, arg2, name="xor_result")
-/// inspect(xor_result, content = "  %xor_result = xor i32 %0, %1")
+/// inspect(xor_result, content="  %xor_result = xor i32 %0, %1")
 /// ```
 pub struct BinaryInst {
   // --- ValueBase ---
@@ -1267,23 +1202,17 @@ pub impl Value for BinaryInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "binary_ops_demo")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createAdd(arg1, arg2)
-///
-/// inspect(add.getValueRepr(), content = "%2")
-///
+/// inspect(add.getValueRepr(), content="%2")
 /// add.setName("sum")
-/// inspect(add.getValueRepr(), content = "%sum")
+/// inspect(add.getValueRepr(), content="%sum")
 /// ```
 pub impl Value for BinaryInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -1304,23 +1233,17 @@ pub impl Value for BinaryInst with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "binary_ops_demo")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createAdd(arg1, arg2)
-///
-/// inspect(add.getName(), content = "None")
-///
+/// inspect(add.getName(), content="None")
 /// add.setName("sum")
-/// inspect(add.getName(), content = "Some(\"sum\")")
+/// inspect(add.getName(), content="Some(\"sum\")")
 /// ```
 pub impl Value for BinaryInst with getName(self) {
   self.name
@@ -1338,23 +1261,17 @@ pub impl Value for BinaryInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "binary_ops_demo")
 /// let bb = fval.addBasicBlock(name="entry")
-///
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let add = builder.createAdd(arg1, arg2)
-///
-/// inspect(add.getName(), content = "None")
-///
+/// inspect(add.getName(), content="None")
 /// add.setName("sum")
-/// inspect(add.getName(), content = "Some(\"sum\")")
+/// inspect(add.getName(), content="Some(\"sum\")")
 /// ```
 pub impl Value for BinaryInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -1508,29 +1425,22 @@ pub impl Show for IntPredicate with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "icmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
-///
 /// let eq_cmp = builder.createICmp(EQ, arg1, arg2, name="eq_cmp")
-/// inspect(eq_cmp, content = "  %eq_cmp = icmp eq i32 %0, %1")
+/// inspect(eq_cmp, content="  %eq_cmp = icmp eq i32 %0, %1")
 /// assert_true(eq_cmp.asValueEnum() is ICmpInst(_))
-///
 /// let ne_cmp = builder.createICmp(NE, arg1, arg2, name="ne_cmp")
-/// inspect(ne_cmp, content = "  %ne_cmp = icmp ne i32 %0, %1")
-///
+/// inspect(ne_cmp, content="  %ne_cmp = icmp ne i32 %0, %1")
 /// let sgt_cmp = builder.createICmp(SGT, arg1, arg2, name="sgt_cmp")
-/// inspect(sgt_cmp, content = "  %sgt_cmp = icmp sgt i32 %0, %1")
-///
+/// inspect(sgt_cmp, content="  %sgt_cmp = icmp sgt i32 %0, %1")
 /// let ugt_cmp = builder.createICmp(UGT, arg1, arg2, name="ugt_cmp")
-/// inspect(ugt_cmp, content = "  %ugt_cmp = icmp ugt i32 %0, %1")
+/// inspect(ugt_cmp, content="  %ugt_cmp = icmp ugt i32 %0, %1")
 /// ```
 pub struct ICmpInst {
   uid : UInt64
@@ -1603,22 +1513,17 @@ pub impl Value for ICmpInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "icmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let eq_cmp = builder.createICmp(EQ, arg1, arg2)
-///
-/// inspect(eq_cmp.getValueRepr(), content = "%2")
-///
+/// inspect(eq_cmp.getValueRepr(), content="%2")
 /// eq_cmp.setName("eq_cmp")
-/// inspect(eq_cmp.getValueRepr(), content = "%eq_cmp")
+/// inspect(eq_cmp.getValueRepr(), content="%eq_cmp")
 /// ```
 pub impl Value for ICmpInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -1639,22 +1544,17 @@ pub impl Value for ICmpInst with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "icmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let eq_cmp = builder.createICmp(EQ, arg1, arg2)
-///
-/// inspect(eq_cmp.getName(), content = "None")
-///
+/// inspect(eq_cmp.getName(), content="None")
 /// eq_cmp.setName("eq_cmp")
-/// inspect(eq_cmp.getName(), content = "Some(\"eq_cmp\")")
+/// inspect(eq_cmp.getName(), content="Some(\"eq_cmp\")")
 /// ```
 pub impl Value for ICmpInst with getName(self) {
   self.name
@@ -1672,22 +1572,17 @@ pub impl Value for ICmpInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "icmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let eq_cmp = builder.createICmp(EQ, arg1, arg2)
-///
-/// inspect(eq_cmp.getName(), content = "None")
-///
+/// inspect(eq_cmp.getName(), content="None")
 /// eq_cmp.setName("eq_cmp")
-/// inspect(eq_cmp.getName(), content = "Some(\"eq_cmp\")")
+/// inspect(eq_cmp.getName(), content="Some(\"eq_cmp\")")
 /// ```
 pub impl Value for ICmpInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -1847,29 +1742,22 @@ pub impl Show for FloatPredicate with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty, f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fcmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
-///
 /// let oeq_cmp = builder.createFCmp(OEQ, arg1, arg2, name="oeq_cmp")
-/// inspect(oeq_cmp, content = "  %oeq_cmp = fcmp oeq float %0, %1")
+/// inspect(oeq_cmp, content="  %oeq_cmp = fcmp oeq float %0, %1")
 /// assert_true(oeq_cmp.asValueEnum() is FCmpInst(_))
-///
 /// let ogt_cmp = builder.createFCmp(OGT, arg1, arg2, name="ogt_cmp")
-/// inspect(ogt_cmp, content = "  %ogt_cmp = fcmp ogt float %0, %1")
-///
+/// inspect(ogt_cmp, content="  %ogt_cmp = fcmp ogt float %0, %1")
 /// let olt_cmp = builder.createFCmp(OLT, arg1, arg2, name="olt_cmp")
-/// inspect(olt_cmp, content = "  %olt_cmp = fcmp olt float %0, %1")
-///
+/// inspect(olt_cmp, content="  %olt_cmp = fcmp olt float %0, %1")
 /// let uno_cmp = builder.createFCmp(UNO, arg1, arg2, name="uno_cmp")
-/// inspect(uno_cmp, content = "  %uno_cmp = fcmp uno float %0, %1")
+/// inspect(uno_cmp, content="  %uno_cmp = fcmp uno float %0, %1")
 /// ```
 pub struct FCmpInst {
   uid : UInt64
@@ -1933,22 +1821,17 @@ pub impl Value for FCmpInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty, f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fcmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let oeq_cmp = builder.createFCmp(OEQ, arg1, arg2)
-///
-/// inspect(oeq_cmp.getValueRepr(), content = "%2")
-///
+/// inspect(oeq_cmp.getValueRepr(), content="%2")
 /// oeq_cmp.setName("oeq_cmp")
-/// inspect(oeq_cmp.getValueRepr(), content = "%oeq_cmp")
+/// inspect(oeq_cmp.getValueRepr(), content="%oeq_cmp")
 /// ```
 pub impl Value for FCmpInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -1974,22 +1857,17 @@ pub impl Value for FCmpInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty, f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fcmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let oeq_cmp = builder.createFCmp(OEQ, arg1, arg2)
-///
-/// inspect(oeq_cmp.getName(), content = "None")
-///
+/// inspect(oeq_cmp.getName(), content="None")
 /// oeq_cmp.setName("oeq_cmp")
-/// inspect(oeq_cmp.getName(), content = "Some(\"oeq_cmp\")")
+/// inspect(oeq_cmp.getName(), content="Some(\"oeq_cmp\")")
 /// ```
 pub impl Value for FCmpInst with getName(self) {
   self.name
@@ -2007,22 +1885,17 @@ pub impl Value for FCmpInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(f32_ty, [f32_ty, f32_ty])
-///
 /// let fval = mod.addFunction(fty, "fcmp_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg1 = fval.getArg(0).unwrap()
 /// let arg2 = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let oeq_cmp = builder.createFCmp(OEQ, arg1, arg2)
-///
-/// inspect(oeq_cmp.getName(), content = "None")
-///
+/// inspect(oeq_cmp.getName(), content="None")
 /// oeq_cmp.setName("oeq_cmp")
-/// inspect(oeq_cmp.getName(), content = "Some(\"oeq_cmp\")")
+/// inspect(oeq_cmp.getName(), content="Some(\"oeq_cmp\")")
 /// ```
 pub impl Value for FCmpInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -2160,27 +2033,21 @@ pub impl Show for CastOps with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let f32_ty = ctx.getFloatTy()
 /// let fty = ctx.getFunctionType(i32_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "cast_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
-///
 /// let trunc = builder.createTrunc(arg, i32_ty, name="truncated")
-/// inspect(trunc, content = "  %truncated = trunc i64 %0 to i32")
+/// inspect(trunc, content="  %truncated = trunc i64 %0 to i32")
 /// assert_true(trunc.asValueEnum() is CastInst(_))
-///
 /// let zext = builder.createZExt(trunc, i64_ty, name="extended")
-/// inspect(zext, content = "  %extended = zext i32 %truncated to i64")
-///
+/// inspect(zext, content="  %extended = zext i32 %truncated to i64")
 /// let bitcast = builder.createBitCast(trunc, f32_ty, name="bits")
-/// inspect(bitcast, content = "  %bits = bitcast i32 %truncated to float")
+/// inspect(bitcast, content="  %bits = bitcast i32 %truncated to float")
 /// ```
 pub struct CastInst {
   uid : UInt64
@@ -2539,22 +2406,17 @@ pub impl Value for CastInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "cast_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let trunc = builder.createTrunc(arg, i32_ty)
-///
-/// inspect(trunc.getValueRepr(), content = "%1")
-///
+/// inspect(trunc.getValueRepr(), content="%1")
 /// trunc.setName("truncated")
-/// inspect(trunc.getValueRepr(), content = "%truncated")
+/// inspect(trunc.getValueRepr(), content="%truncated")
 /// ```
 pub impl Value for CastInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -2580,22 +2442,17 @@ pub impl Value for CastInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "cast_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let trunc = builder.createTrunc(arg, i32_ty)
-///
-/// inspect(trunc.getName(), content = "None")
-///
+/// inspect(trunc.getName(), content="None")
 /// trunc.setName("truncated")
-/// inspect(trunc.getName(), content = "Some(\"truncated\")")
+/// inspect(trunc.getName(), content="Some(\"truncated\")")
 /// ```
 pub impl Value for CastInst with getName(self) {
   self.name
@@ -2613,22 +2470,17 @@ pub impl Value for CastInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let i64_ty = ctx.getInt64Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i64_ty])
-///
 /// let fval = mod.addFunction(fty, "cast_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let trunc = builder.createTrunc(arg, i32_ty)
-///
-/// inspect(trunc.getName(), content = "None")
-///
+/// inspect(trunc.getName(), content="None")
 /// trunc.setName("truncated")
-/// inspect(trunc.getName(), content = "Some(\"truncated\")")
+/// inspect(trunc.getName(), content="Some(\"truncated\")")
 /// ```
 pub impl Value for CastInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -2734,22 +2586,27 @@ pub impl Show for CastInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let array_ty = ctx.getArrayType(i32_ty, 10)
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ptr_ty, [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "gep_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
 /// let zero = ctx.getConstInt32(0)
 /// let two = ctx.getConstInt32(2)
-///
 /// builder.setInsertPoint(bb)
-/// let gep = builder.createGEP(arg, array_ty, [zero, two], name="elem_ptr", inbounds=true)
-///
-/// inspect(gep, content = "  %elem_ptr = getelementptr inbounds [10 x i32], ptr %0, i32 0, i32 2")
+/// let gep = builder.createGEP(
+///   arg,
+///   array_ty,
+///   [zero, two],
+///   name="elem_ptr",
+///   inbounds=true,
+/// )
+/// inspect(
+///   gep,
+///   content="  %elem_ptr = getelementptr inbounds [10 x i32], ptr %0, i32 0, i32 2",
+/// )
 /// assert_true(gep.asValueEnum() is GetElementPtrInst(_))
 /// ```
 pub struct GetElementPtrInst {
@@ -2814,25 +2671,20 @@ pub impl Value for GetElementPtrInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let array_ty = ctx.getArrayType(i32_ty, 10)
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ptr_ty, [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "gep_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
 /// let zero = ctx.getConstInt32(0)
 /// let two = ctx.getConstInt32(2)
-///
 /// builder.setInsertPoint(bb)
 /// let gep = builder.createGEP(arg, array_ty, [zero, two])
-///
-/// inspect(gep.getValueRepr(), content = "%1")
-///
+/// inspect(gep.getValueRepr(), content="%1")
 /// gep.setName("elem_ptr")
-/// inspect(gep.getValueRepr(), content = "%elem_ptr")
+/// inspect(gep.getValueRepr(), content="%elem_ptr")
 /// ```
 pub impl Value for GetElementPtrInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -2858,25 +2710,20 @@ pub impl Value for GetElementPtrInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let array_ty = ctx.getArrayType(i32_ty, 10)
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ptr_ty, [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "gep_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
 /// let zero = ctx.getConstInt32(0)
 /// let two = ctx.getConstInt32(2)
-///
 /// builder.setInsertPoint(bb)
 /// let gep = builder.createGEP(arg, array_ty, [zero, two])
-///
-/// inspect(gep.getName(), content = "None")
-///
+/// inspect(gep.getName(), content="None")
 /// gep.setName("elem_ptr")
-/// inspect(gep.getName(), content = "Some(\"elem_ptr\")")
+/// inspect(gep.getName(), content="Some(\"elem_ptr\")")
 /// ```
 pub impl Value for GetElementPtrInst with getName(self) {
   self.name
@@ -2894,25 +2741,20 @@ pub impl Value for GetElementPtrInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let array_ty = ctx.getArrayType(i32_ty, 10)
 /// let ptr_ty = ctx.getPtrTy()
 /// let fty = ctx.getFunctionType(ptr_ty, [ptr_ty])
-///
 /// let fval = mod.addFunction(fty, "gep_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
 /// let zero = ctx.getConstInt32(0)
 /// let two = ctx.getConstInt32(2)
-///
 /// builder.setInsertPoint(bb)
 /// let gep = builder.createGEP(arg, array_ty, [zero, two])
-///
-/// inspect(gep.getName(), content = "None")
-///
+/// inspect(gep.getName(), content="None")
 /// gep.setName("elem_ptr")
-/// inspect(gep.getName(), content = "Some(\"elem_ptr\")")
+/// inspect(gep.getName(), content="Some(\"elem_ptr\")")
 /// ```
 pub impl Value for GetElementPtrInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -3021,21 +2863,17 @@ pub impl Show for GetElementPtrInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i1_ty, i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "select_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let cond = fval.getArg(0).unwrap()
 /// let true_val = fval.getArg(1).unwrap()
 /// let false_val = fval.getArg(2).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let select = builder.createSelect(cond, true_val, false_val, name="result")
-///
-/// inspect(select, content = "  %result = select i1 %0, i32 %1, i32 %2")
+/// inspect(select, content="  %result = select i1 %0, i32 %1, i32 %2")
 /// assert_true(select.asValueEnum() is SelectInst(_))
 /// ```
 pub struct SelectInst {
@@ -3113,24 +2951,19 @@ pub impl Value for SelectInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i1_ty, i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "select_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let cond = fval.getArg(0).unwrap()
 /// let true_val = fval.getArg(1).unwrap()
 /// let false_val = fval.getArg(2).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let select = builder.createSelect(cond, true_val, false_val)
-///
-/// inspect(select.getValueRepr(), content = "%3")
-///
+/// inspect(select.getValueRepr(), content="%3")
 /// select.setName("result")
-/// inspect(select.getValueRepr(), content = "%result")
+/// inspect(select.getValueRepr(), content="%result")
 /// ```
 pub impl Value for SelectInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -3156,24 +2989,19 @@ pub impl Value for SelectInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i1_ty, i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "select_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let cond = fval.getArg(0).unwrap()
 /// let true_val = fval.getArg(1).unwrap()
 /// let false_val = fval.getArg(2).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let select = builder.createSelect(cond, true_val, false_val)
-///
-/// inspect(select.getName(), content = "None")
-///
+/// inspect(select.getName(), content="None")
 /// select.setName("result")
-/// inspect(select.getName(), content = "Some(\"result\")")
+/// inspect(select.getName(), content="Some(\"result\")")
 /// ```
 pub impl Value for SelectInst with getName(self) {
   self.name
@@ -3191,24 +3019,19 @@ pub impl Value for SelectInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [i1_ty, i32_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "select_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let cond = fval.getArg(0).unwrap()
 /// let true_val = fval.getArg(1).unwrap()
 /// let false_val = fval.getArg(2).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let select = builder.createSelect(cond, true_val, false_val)
-///
-/// inspect(select.getName(), content = "None")
-///
+/// inspect(select.getName(), content="None")
 /// select.setName("result")
-/// inspect(select.getName(), content = "Some(\"result\")")
+/// inspect(select.getName(), content="Some(\"result\")")
 /// ```
 pub impl Value for SelectInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -3314,28 +3137,22 @@ pub impl Show for SelectInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(i32_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "return_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let arg = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let ret = builder.createRet(arg)
-///
-/// inspect(ret, content = "  ret i32 %0")
+/// inspect(ret, content="  ret i32 %0")
 /// assert_true(ret.asValueEnum() is ReturnInst(_))
-///
 /// let void_fty = ctx.getFunctionType(void_ty, [])
 /// let void_fval = mod.addFunction(void_fty, "void_return_demo")
 /// let void_bb = void_fval.addBasicBlock(name="entry")
 /// builder.setInsertPoint(void_bb)
 /// let void_ret = builder.createRetVoid()
-///
-/// inspect(void_ret, content = "  ret void")
+/// inspect(void_ret, content="  ret void")
 /// ```
 pub struct ReturnInst {
   uid : UInt64
@@ -3457,27 +3274,21 @@ pub impl Show for ReturnInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i1_ty = ctx.getInt1Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i1_ty])
-///
 /// let fval = mod.addFunction(fty, "branch_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let true_bb = fval.addBasicBlock(name="true_branch")
 /// let false_bb = fval.addBasicBlock(name="false_branch")
 /// let cond = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let cond_br = builder.createCondBr(cond, true_bb, false_bb)
-///
-/// inspect(cond_br, content = "  br i1 %0, label %true_branch, label %false_branch")
+/// inspect(cond_br, content="  br i1 %0, label %true_branch, label %false_branch")
 /// assert_true(cond_br.asValueEnum() is BranchInst(_))
-///
 /// builder.setInsertPoint(true_bb)
 /// let uncond_br = builder.createBr(false_bb)
-///
-/// inspect(uncond_br, content = "  br label %false_branch")
+/// inspect(uncond_br, content="  br label %false_branch")
 /// ```
 pub struct BranchInst {
   // --- ValueBase ---
@@ -3692,32 +3503,27 @@ pub impl Show for BranchInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "switch_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let case1_bb = fval.addBasicBlock(name="case1")
 /// let case2_bb = fval.addBasicBlock(name="case2")
 /// let default_bb = fval.addBasicBlock(name="default")
 /// let value = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let switch = builder.createSwitch(value, default_bb)
 /// let case_val1 = ctx.getConstInt32(1)
 /// let case_val2 = ctx.getConstInt32(2)
 /// switch.addCase(case_val1, case1_bb)
 /// switch.addCase(case_val2, case2_bb)
-///
-/// let expect = 
+/// let expect =
 ///   #|  switch i32 %0, label %default [
 ///   #|    i32 1, label %case1
 ///   #|    i32 2, label %case2
 ///   #|  ]
-///
-/// inspect(switch, content = expect)
+/// inspect(switch, content=expect)
 /// assert_true(switch.asValueEnum() is SwitchInst(_))
 /// ```
 pub struct SwitchInst {
@@ -3787,31 +3593,27 @@ pub fn SwitchInst::getNumCases(self : Self) -> Int {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "switch_case_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let case1_bb = fval.addBasicBlock(name="case1")
 /// let case2_bb = fval.addBasicBlock(name="case2")
 /// let default_bb = fval.addBasicBlock(name="default")
 /// let value = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let switch = builder.createSwitch(value, default_bb)
 /// let case_val1 = ctx.getConstInt32(1)
 /// let case_val2 = ctx.getConstInt32(2)
 /// switch.addCase(case_val1, case1_bb)
 /// switch.addCase(case_val2, case2_bb)
-///
-/// inspect(switch.getNumCases(), content = "2")
-/// inspect(switch.getCase(0).unwrap().0.getValueRepr(), content = "1")
-/// inspect(switch.getCase(0).unwrap().1.getValueRepr(), content = "%case1")
-/// inspect(switch.getCase(1).unwrap().0.getValueRepr(), content = "2")
-/// inspect(switch.getCase(1).unwrap().1.getValueRepr(), content = "%case2")
-/// inspect(switch.getCase(2), content = "None")
+/// inspect(switch.getNumCases(), content="2")
+/// inspect(switch.getCase(0).unwrap().0.getValueRepr(), content="1")
+/// inspect(switch.getCase(0).unwrap().1.getValueRepr(), content="%case1")
+/// inspect(switch.getCase(1).unwrap().0.getValueRepr(), content="2")
+/// inspect(switch.getCase(1).unwrap().1.getValueRepr(), content="%case2")
+/// inspect(switch.getCase(2), content="None")
 /// ```
 pub fn SwitchInst::getCase(
   self : Self,
@@ -3832,11 +3634,9 @@ pub fn SwitchInst::getCase(
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let void_ty = ctx.getVoidTy()
 /// let fty = ctx.getFunctionType(void_ty, [i32_ty])
-///
 /// let fval = mod.addFunction(fty, "switch_addcase_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let case1_bb = fval.addBasicBlock(name="case1")
@@ -3844,7 +3644,6 @@ pub fn SwitchInst::getCase(
 /// let case3_bb = fval.addBasicBlock(name="case3")
 /// let default_bb = fval.addBasicBlock(name="default")
 /// let value = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(entry_bb)
 /// let switch = builder.createSwitch(value, default_bb)
 ///
@@ -3855,8 +3654,7 @@ pub fn SwitchInst::getCase(
 /// switch.addCase(case_val1, case1_bb)
 /// switch.addCase(case_val2, case2_bb)
 /// switch.addCase(case_val3, case3_bb)
-///
-/// inspect(switch.getNumCases(), content = "3")
+/// inspect(switch.getNumCases(), content="3")
 /// assert_true(switch.getCase(0).unwrap().0.getValueRepr() == "1")
 /// assert_true(switch.getCase(1).unwrap().0.getValueRepr() == "2")
 /// assert_true(switch.getCase(2).unwrap().0.getValueRepr() == "3")
@@ -4007,23 +3805,19 @@ pub impl Show for SwitchInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block_bb = fval.addBasicBlock(name="block")
 /// let merge_bb = fval.addBasicBlock(name="merge")
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block_bb)
-///
-/// inspect(phi, content = "  %result = phi i32 [ 10, %entry ], [ 20, %block ]")
+/// inspect(phi, content="  %result = phi i32 [ 10, %entry ], [ 20, %block ]")
 /// assert_true(phi.asValueEnum() is PHINode(_))
 /// ```
 pub struct PHINode {
@@ -4060,10 +3854,8 @@ fn PHINode::new(vty : &Type, parent : Function, name~ : String?) -> PHINode {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_num_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block1_bb = fval.addBasicBlock(name="block1")
@@ -4072,18 +3864,14 @@ fn PHINode::new(vty : &Type, parent : Function, name~ : String?) -> PHINode {
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
 /// let val3 = ctx.getConstInt32(30)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
-///
-/// inspect(phi.getNumIncomingValues(), content = "0")
-///
+/// inspect(phi.getNumIncomingValues(), content="0")
 /// phi.addIncoming(val1, entry_bb)
-/// inspect(phi.getNumIncomingValues(), content = "1")
-///
+/// inspect(phi.getNumIncomingValues(), content="1")
 /// phi.addIncoming(val2, block1_bb)
 /// phi.addIncoming(val3, block2_bb)
-/// inspect(phi.getNumIncomingValues(), content = "3")
+/// inspect(phi.getNumIncomingValues(), content="3")
 /// ```
 pub fn PHINode::getNumIncomingValues(self : PHINode) -> Int {
   self.incomings.length()
@@ -4100,25 +3888,21 @@ pub fn PHINode::getNumIncomingValues(self : PHINode) -> Int {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_value_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block_bb = fval.addBasicBlock(name="block")
 /// let merge_bb = fval.addBasicBlock(name="merge")
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block_bb)
-///
-/// inspect(phi.getIncomingValue(0).unwrap().getValueRepr(), content = "10")
-/// inspect(phi.getIncomingValue(1).unwrap().getValueRepr(), content = "20")
-/// inspect(phi.getIncomingValue(2), content = "None")
+/// inspect(phi.getIncomingValue(0).unwrap().getValueRepr(), content="10")
+/// inspect(phi.getIncomingValue(1).unwrap().getValueRepr(), content="20")
+/// inspect(phi.getIncomingValue(2), content="None")
 /// ```
 pub fn PHINode::getIncomingValue(self : PHINode, idx : Int) -> &Value? {
   match self.incomings.get(idx) {
@@ -4138,25 +3922,21 @@ pub fn PHINode::getIncomingValue(self : PHINode, idx : Int) -> &Value? {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_block_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block_bb = fval.addBasicBlock(name="block")
 /// let merge_bb = fval.addBasicBlock(name="merge")
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block_bb)
-///
-/// inspect(phi.getIncomingBlock(0).unwrap().getValueRepr(), content = "%entry")
-/// inspect(phi.getIncomingBlock(1).unwrap().getValueRepr(), content = "%block")
-/// inspect(phi.getIncomingBlock(2), content = "None")
+/// inspect(phi.getIncomingBlock(0).unwrap().getValueRepr(), content="%entry")
+/// inspect(phi.getIncomingBlock(1).unwrap().getValueRepr(), content="%block")
+/// inspect(phi.getIncomingBlock(2), content="None")
 /// ```
 pub fn PHINode::getIncomingBlock(self : PHINode, idx : Int) -> BasicBlock? {
   match self.incomings.get(idx) {
@@ -4176,31 +3956,25 @@ pub fn PHINode::getIncomingBlock(self : PHINode, idx : Int) -> BasicBlock? {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_incoming_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block_bb = fval.addBasicBlock(name="block")
 /// let merge_bb = fval.addBasicBlock(name="merge")
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block_bb)
-///
 /// let (value0, block0) = phi.getIncoming(0).unwrap()
-/// inspect(value0.getValueRepr(), content = "10")
-/// inspect(block0.getValueRepr(), content = "%entry")
-///
+/// inspect(value0.getValueRepr(), content="10")
+/// inspect(block0.getValueRepr(), content="%entry")
 /// let (value1, block1) = phi.getIncoming(1).unwrap()
-/// inspect(value1.getValueRepr(), content = "20")
-/// inspect(block1.getValueRepr(), content = "%block")
-///
-/// inspect(phi.getIncoming(2), content = "None")
+/// inspect(value1.getValueRepr(), content="20")
+/// inspect(block1.getValueRepr(), content="%block")
+/// inspect(phi.getIncoming(2), content="None")
 /// ```
 pub fn PHINode::getIncoming(self : PHINode, idx : Int) -> (&Value, BasicBlock)? {
   self.incomings.get(idx)
@@ -4217,10 +3991,8 @@ pub fn PHINode::getIncoming(self : PHINode, idx : Int) -> (&Value, BasicBlock)? 
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_incomings_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block1_bb = fval.addBasicBlock(name="block1")
@@ -4229,19 +4001,17 @@ pub fn PHINode::getIncoming(self : PHINode, idx : Int) -> (&Value, BasicBlock)? 
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
 /// let val3 = ctx.getConstInt32(30)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block1_bb)
 /// phi.addIncoming(val3, block2_bb)
-///
 /// let incomings = phi.getIncomings()
-/// inspect(incomings.length(), content = "3")
-/// inspect(incomings[0].0.getValueRepr(), content = "10")
-/// inspect(incomings[0].1.getValueRepr(), content = "%entry")
-/// inspect(incomings[1].0.getValueRepr(), content = "20")
-/// inspect(incomings[2].0.getValueRepr(), content = "30")
+/// inspect(incomings.length(), content="3")
+/// inspect(incomings[0].0.getValueRepr(), content="10")
+/// inspect(incomings[0].1.getValueRepr(), content="%entry")
+/// inspect(incomings[1].0.getValueRepr(), content="20")
+/// inspect(incomings[2].0.getValueRepr(), content="30")
 /// ```
 pub fn PHINode::getIncomings(self : PHINode) -> Array[(&Value, BasicBlock)] {
   self.incomings
@@ -4258,10 +4028,8 @@ pub fn PHINode::getIncomings(self : PHINode) -> Array[(&Value, BasicBlock)] {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_values_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block1_bb = fval.addBasicBlock(name="block1")
@@ -4270,18 +4038,16 @@ pub fn PHINode::getIncomings(self : PHINode) -> Array[(&Value, BasicBlock)] {
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
 /// let val3 = ctx.getConstInt32(30)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block1_bb)
 /// phi.addIncoming(val3, block2_bb)
-///
 /// let values = phi.getIncomingValues()
-/// inspect(values.length(), content = "3")
-/// inspect(values[0].getValueRepr(), content = "10")
-/// inspect(values[1].getValueRepr(), content = "20")
-/// inspect(values[2].getValueRepr(), content = "30")
+/// inspect(values.length(), content="3")
+/// inspect(values[0].getValueRepr(), content="10")
+/// inspect(values[1].getValueRepr(), content="20")
+/// inspect(values[2].getValueRepr(), content="30")
 /// ```
 pub fn PHINode::getIncomingValues(self : PHINode) -> Array[&Value] {
   self.incomings.map(incoming => incoming.0)
@@ -4298,10 +4064,8 @@ pub fn PHINode::getIncomingValues(self : PHINode) -> Array[&Value] {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_blocks_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block1_bb = fval.addBasicBlock(name="block1")
@@ -4310,18 +4074,16 @@ pub fn PHINode::getIncomingValues(self : PHINode) -> Array[&Value] {
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
 /// let val3 = ctx.getConstInt32(30)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
 /// phi.addIncoming(val1, entry_bb)
 /// phi.addIncoming(val2, block1_bb)
 /// phi.addIncoming(val3, block2_bb)
-///
 /// let blocks = phi.getIncomingBlocks()
-/// inspect(blocks.length(), content = "3")
-/// inspect(blocks[0].getValueRepr(), content = "%entry")
-/// inspect(blocks[1].getValueRepr(), content = "%block1")
-/// inspect(blocks[2].getValueRepr(), content = "%block2")
+/// inspect(blocks.length(), content="3")
+/// inspect(blocks[0].getValueRepr(), content="%entry")
+/// inspect(blocks[1].getValueRepr(), content="%block1")
+/// inspect(blocks[2].getValueRepr(), content="%block2")
 /// ```
 pub fn PHINode::getIncomingBlocks(self : PHINode) -> Array[BasicBlock] {
   self.incomings.map(incoming => incoming.1)
@@ -4339,10 +4101,8 @@ pub fn PHINode::getIncomingBlocks(self : PHINode) -> Array[BasicBlock] {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_add_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
 /// let block1_bb = fval.addBasicBlock(name="block1")
@@ -4351,23 +4111,18 @@ pub fn PHINode::getIncomingBlocks(self : PHINode) -> Array[BasicBlock] {
 /// let val1 = ctx.getConstInt32(10)
 /// let val2 = ctx.getConstInt32(20)
 /// let val3 = ctx.getConstInt32(30)
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty, name="result")
-///
-/// inspect(phi.getNumIncomingValues(), content = "0")
-///
+/// inspect(phi.getNumIncomingValues(), content="0")
 /// phi.addIncoming(val1, entry_bb)
-/// inspect(phi.getNumIncomingValues(), content = "1")
-/// inspect(phi.getIncomingValue(0).unwrap().getValueRepr(), content = "10")
-/// inspect(phi.getIncomingBlock(0).unwrap().getValueRepr(), content = "%entry")
-///
+/// inspect(phi.getNumIncomingValues(), content="1")
+/// inspect(phi.getIncomingValue(0).unwrap().getValueRepr(), content="10")
+/// inspect(phi.getIncomingBlock(0).unwrap().getValueRepr(), content="%entry")
 /// phi.addIncoming(val2, block1_bb)
 /// phi.addIncoming(val3, block2_bb)
-/// inspect(phi.getNumIncomingValues(), content = "3")
-///
+/// inspect(phi.getNumIncomingValues(), content="3")
 /// let expected = "  %result = phi i32 [ 10, %entry ], [ 20, %block1 ], [ 30, %block2 ]"
-/// inspect(phi, content = expected)
+/// inspect(phi, content=expected)
 /// ```
 pub fn PHINode::addIncoming(
   self : PHINode,
@@ -4396,20 +4151,15 @@ pub impl Value for PHINode with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(entry_bb)
 /// let phi = builder.createPHI(i32_ty)
-///
-/// inspect(phi.getValueRepr(), content = "%0")
-///
+/// inspect(phi.getValueRepr(), content="%0")
 /// phi.setName("result")
-/// inspect(phi.getValueRepr(), content = "%result")
+/// inspect(phi.getValueRepr(), content="%result")
 /// ```
 pub impl Value for PHINode with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -4430,20 +4180,15 @@ pub impl Value for PHINode with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_demo")
 /// let entry_bb = fval.addBasicBlock(name="entry")
-///
 /// builder.setInsertPoint(entry_bb)
 /// let phi = builder.createPHI(i32_ty)
-///
-/// inspect(phi.getName(), content = "None")
-///
+/// inspect(phi.getName(), content="None")
 /// phi.setName("result")
-/// inspect(phi.getName(), content = "Some(\"result\")")
+/// inspect(phi.getName(), content="Some(\"result\")")
 /// ```
 pub impl Value for PHINode with getName(self) {
   self.name
@@ -4461,20 +4206,15 @@ pub impl Value for PHINode with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let fval = mod.addFunction(fty, "phi_demo")
 /// let merge_bb = fval.addBasicBlock(name="merge")
-///
 /// builder.setInsertPoint(merge_bb)
 /// let phi = builder.createPHI(i32_ty)
-///
-/// inspect(phi.getName(), content = "None")
-///
+/// inspect(phi.getName(), content="None")
 /// phi.setName("result")
-/// inspect(phi.getName(), content = "Some(\"result\")")
+/// inspect(phi.getName(), content="Some(\"result\")")
 /// ```
 pub impl Value for PHINode with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -4610,28 +4350,22 @@ pub impl Show for TailCallKind with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let add_fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let main_fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let add_func = mod.addFunction(add_fty, "add")
 /// let main_func = mod.addFunction(main_fty, "main")
 /// let bb = main_func.addBasicBlock(name="entry")
 /// let arg1 = ctx.getConstInt32(10)
 /// let arg2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(bb)
 /// let call = builder.createCall(add_func, [arg1, arg2], name="sum")
-///
-/// inspect(call, content = "  %sum = call i32 @add(i32 10, i32 20)")
+/// inspect(call, content="  %sum = call i32 @add(i32 10, i32 20)")
 /// assert_true(call.asValueEnum() is CallInst(_))
-///
 /// let void_fty = ctx.getFunctionType(ctx.getVoidTy(), [])
 /// let void_func = mod.addFunction(void_fty, "void_func")
 /// let void_call = builder.createCall(void_func, [])
-///
-/// inspect(void_call, content = "  call void @void_func()")
+/// inspect(void_call, content="  call void @void_func()")
 /// ```
 pub struct CallInst {
   uid : UInt64
@@ -4784,24 +4518,19 @@ pub impl Value for CallInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let add_fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let main_fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let add_func = mod.addFunction(add_fty, "add")
 /// let main_func = mod.addFunction(main_fty, "main")
 /// let bb = main_func.addBasicBlock(name="entry")
 /// let arg1 = ctx.getConstInt32(10)
 /// let arg2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(bb)
 /// let call = builder.createCall(add_func, [arg1, arg2])
-///
-/// inspect(call.getValueRepr(), content = "%0")
-///
+/// inspect(call.getValueRepr(), content="%0")
 /// call.setName("sum")
-/// inspect(call.getValueRepr(), content = "%sum")
+/// inspect(call.getValueRepr(), content="%sum")
 /// ```
 pub impl Value for CallInst with getValueRepr(self) {
   if self.vty.asTypeEnum() is VoidType(_) {
@@ -4825,24 +4554,19 @@ pub impl Value for CallInst with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let add_fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let main_fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let add_func = mod.addFunction(add_fty, "add")
 /// let main_func = mod.addFunction(main_fty, "main")
 /// let bb = main_func.addBasicBlock(name="entry")
 /// let arg1 = ctx.getConstInt32(10)
 /// let arg2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(bb)
 /// let call = builder.createCall(add_func, [arg1, arg2])
-///
-/// inspect(call.getName(), content = "None")
-///
+/// inspect(call.getName(), content="None")
 /// call.setName("sum")
-/// inspect(call.getName(), content = "Some(\"sum\")")
+/// inspect(call.getName(), content="Some(\"sum\")")
 /// ```
 pub impl Value for CallInst with getName(self) {
   self.name
@@ -4875,24 +4599,19 @@ pub impl Value for CallInst with getNameOrSlot(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let add_fty = ctx.getFunctionType(i32_ty, [i32_ty, i32_ty])
 /// let main_fty = ctx.getFunctionType(i32_ty, [])
-///
 /// let add_func = mod.addFunction(add_fty, "add")
 /// let main_func = mod.addFunction(main_fty, "main")
 /// let bb = main_func.addBasicBlock(name="entry")
 /// let arg1 = ctx.getConstInt32(10)
 /// let arg2 = ctx.getConstInt32(20)
-///
 /// builder.setInsertPoint(bb)
 /// let call = builder.createCall(add_func, [arg1, arg2])
-///
-/// inspect(call.getName(), content = "None")
-///
+/// inspect(call.getName(), content="None")
 /// call.setName("sum")
-/// inspect(call.getName(), content = "Some(\"sum\")")
+/// inspect(call.getName(), content="Some(\"sum\")")
 /// ```
 pub impl Value for CallInst with setName(self, name) {
   if self.vty.asTypeEnum() is VoidType(_) {
@@ -5060,19 +4779,15 @@ pub impl Show for CallInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(i32_ty, [struct_ty])
-///
 /// let fval = mod.addFunction(fty, "extractvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let extract = builder.createExtractValue(aggregate, [0], name="field")
-///
-/// inspect(extract, content = "  %field = extractvalue { i32, i32 } %0, 0")
+/// inspect(extract, content="  %field = extractvalue { i32, i32 } %0, 0")
 /// assert_true(extract.asValueEnum() is ExtractValueInst(_))
 /// ```
 pub struct ExtractValueInst {
@@ -5143,22 +4858,17 @@ pub impl Value for ExtractValueInst with getValueBase(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(i32_ty, [struct_ty])
-///
 /// let fval = mod.addFunction(fty, "extractvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let extract = builder.createExtractValue(aggregate, [0])
-///
-/// inspect(extract.getValueRepr(), content = "%1")
-///
+/// inspect(extract.getValueRepr(), content="%1")
 /// extract.setName("field")
-/// inspect(extract.getValueRepr(), content = "%field")
+/// inspect(extract.getValueRepr(), content="%field")
 /// ```
 pub impl Value for ExtractValueInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -5184,22 +4894,17 @@ pub impl Value for ExtractValueInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(i32_ty, [struct_ty])
-///
 /// let fval = mod.addFunction(fty, "extractvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let extract = builder.createExtractValue(aggregate, [0])
-///
-/// inspect(extract.getName(), content = "None")
-///
+/// inspect(extract.getName(), content="None")
 /// extract.setName("field")
-/// inspect(extract.getName(), content = "Some(\"field\")")
+/// inspect(extract.getName(), content="Some(\"field\")")
 /// ```
 pub impl Value for ExtractValueInst with getName(self) {
   self.name
@@ -5217,22 +4922,17 @@ pub impl Value for ExtractValueInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(i32_ty, [struct_ty])
-///
 /// let fval = mod.addFunction(fty, "extractvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let extract = builder.createExtractValue(aggregate, [0])
-///
-/// inspect(extract.getName(), content = "None")
-///
+/// inspect(extract.getName(), content="None")
 /// extract.setName("field")
-/// inspect(extract.getName(), content = "Some(\"field\")")
+/// inspect(extract.getName(), content="Some(\"field\")")
 /// ```
 pub impl Value for ExtractValueInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {
@@ -5339,20 +5039,21 @@ pub impl Show for ExtractValueInst with output(self, logger) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(struct_ty, [struct_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "insertvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
 /// let new_value = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
-/// let insert = builder.createInsertValue(aggregate, new_value, [1], name="updated")
-///
-/// inspect(insert, content = "  %updated = insertvalue { i32, i32 } %0, i32 %1, 1")
+/// let insert = builder.createInsertValue(
+///   aggregate,
+///   new_value,
+///   [1],
+///   name="updated",
+/// )
+/// inspect(insert, content="  %updated = insertvalue { i32, i32 } %0, i32 %1, 1")
 /// assert_true(insert.asValueEnum() is InsertValueInst(_))
 /// ```
 pub struct InsertValueInst {
@@ -5439,23 +5140,18 @@ pub impl Value for InsertValueInst with asValueEnum(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(struct_ty, [struct_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "insertvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
 /// let new_value = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let insert = builder.createInsertValue(aggregate, new_value, [1])
-///
-/// inspect(insert.getValueRepr(), content = "%2")
-///
+/// inspect(insert.getValueRepr(), content="%2")
 /// insert.setName("updated")
-/// inspect(insert.getValueRepr(), content = "%updated")
+/// inspect(insert.getValueRepr(), content="%updated")
 /// ```
 pub impl Value for InsertValueInst with getValueRepr(self) {
   match self.getNameOrSlot() {
@@ -5476,23 +5172,18 @@ pub impl Value for InsertValueInst with getValueRepr(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(struct_ty, [struct_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "insertvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
 /// let new_value = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let insert = builder.createInsertValue(aggregate, new_value, [1])
-///
-/// inspect(insert.getName(), content = "None")
-///
+/// inspect(insert.getName(), content="None")
 /// insert.setName("updated")
-/// inspect(insert.getName(), content = "Some(\"updated\")")
+/// inspect(insert.getName(), content="Some(\"updated\")")
 /// ```
 pub impl Value for InsertValueInst with getName(self) {
   self.name
@@ -5510,23 +5201,18 @@ pub impl Value for InsertValueInst with getName(self) {
 /// let ctx = Context::new()
 /// let mod = ctx.addModule("demo")
 /// let builder = ctx.createBuilder()
-///
 /// let i32_ty = ctx.getInt32Ty()
 /// let struct_ty = ctx.getStructType([i32_ty, i32_ty])
 /// let fty = ctx.getFunctionType(struct_ty, [struct_ty, i32_ty])
-///
 /// let fval = mod.addFunction(fty, "insertvalue_demo")
 /// let bb = fval.addBasicBlock(name="entry")
 /// let aggregate = fval.getArg(0).unwrap()
 /// let new_value = fval.getArg(1).unwrap()
-///
 /// builder.setInsertPoint(bb)
 /// let insert = builder.createInsertValue(aggregate, new_value, [1])
-///
-/// inspect(insert.getName(), content = "None")
-///
+/// inspect(insert.getName(), content="None")
 /// insert.setName("updated")
-/// inspect(insert.getName(), content = "Some(\"updated\")")
+/// inspect(insert.getName(), content="Some(\"updated\")")
 /// ```
 pub impl Value for InsertValueInst with setName(self, name) {
   match self.getParent().setSymbol(name, self) {

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -474,7 +474,7 @@ impl Type with tryAsAbstractTypeEnum(self) -> AbstractTypeEnum? {
 ///|
 /// Collection of Int1Type, Int8Type, Int16Type, Int32Type, Int64Type
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8ty :&IntegerType = ctx.getInt8Ty()
@@ -985,7 +985,7 @@ pub impl PrimitiveType for FP128Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// - See LLVM: `Type::getInt1Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getInt1Ty(), content="i1")
@@ -1033,7 +1033,7 @@ pub impl PrimitiveType for Int1Type with asPrimitiveTypeEnum(self) -> PrimitiveT
 ///
 /// - See LLVM: `Type::getInt8Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getInt8Ty(), content="i8")
@@ -1086,7 +1086,7 @@ pub impl PrimitiveType for Int8Type with asPrimitiveTypeEnum(self) -> PrimitiveT
 ///
 /// - See LLVM: `Type::getInt16Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getInt16Ty(), content="i16")
@@ -1139,7 +1139,7 @@ pub impl PrimitiveType for Int16Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// - See LLVM: `Type::getInt32Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getInt32Ty(), content="i32")
@@ -1192,7 +1192,7 @@ pub impl PrimitiveType for Int32Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// - See LLVM: `Type::getInt64Ty`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getInt64Ty(), content="i64")
@@ -1246,7 +1246,7 @@ pub struct VoidType {
 ///
 /// - See LLVM: `Type::getVoidTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let voidty = ctx.getVoidTy()
 /// inspect(voidty, content="void")
@@ -1290,7 +1290,7 @@ pub struct LabelType {
 ///
 /// - See LLVM: `Type::getLabelTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let labelty = ctx.getLabelTy()
 /// inspect(labelty, content="label")
@@ -1333,7 +1333,7 @@ pub struct MetadataType {
 ///
 /// - See LLVM: `Type::getMetadataTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let metadataty = ctx.getMetadataTy()
 /// inspect(metadataty, content="metadata")
@@ -1377,7 +1377,7 @@ pub struct TokenType {
 ///
 /// - See LLVM: `Type::getTokenTy`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let tokenty = ctx.getTokenTy()
 /// inspect(tokenty, content="token")
@@ -1415,7 +1415,7 @@ pub impl AbstractType for TokenType with asAbstractTypeEnum(self) -> AbstractTyp
 ///
 /// See LLVM: `FunctionType::FunctionType`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let int32ty = ctx.getInt32Ty()
 /// let voidty = ctx.getVoidTy()
@@ -1544,7 +1544,7 @@ pub impl AbstractType for FunctionType with asAbstractTypeEnum(self) -> Abstract
 ///
 /// - See LLVM: `StructType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i8ty = ctx.getInt8Ty()
@@ -1609,7 +1609,7 @@ fn StructType::new(
 ///
 /// - See LLVM: `StructType::isLiteral`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -1631,7 +1631,7 @@ pub fn StructType::isLiteral(self : StructType) -> Bool {
 ///
 /// - See LLVM: `StructType::isOpaque`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
@@ -1840,7 +1840,7 @@ pub impl AggregateType for StructType with asAggregateTypeEnum(self) -> Aggregat
 ///
 /// - See LLVM: `ArrayType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i32ty = ctx.getInt32Ty()
@@ -1917,7 +1917,7 @@ pub impl AggregateType for ArrayType with asAggregateTypeEnum(self) -> Aggregate
 ///
 /// - See LLVM: `VectorType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let i32ty = ctx.getInt32Ty()
@@ -1998,7 +1998,7 @@ pub impl AggregateType for VectorType with asAggregateTypeEnum(self) -> Aggregat
 ///
 /// - See LLVM: `ScalableVectorType::get`.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// let f32ty = ctx.getFloatTy()
@@ -2093,7 +2093,7 @@ pub fn AddressSpace::new(v : UInt) -> AddressSpace {
 /// In Moonbit Aether framework, we follow the design of LLVM20, so all pointer is
 /// also opaque pointer, and will not mark type for pointer.
 ///
-/// ```moonbit
+/// ```mbt test
 /// let ctx = Context::new()
 ///
 /// inspect(ctx.getPtrTy(), content="ptr")

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -476,16 +476,12 @@ impl Type with tryAsAbstractTypeEnum(self) -> AbstractTypeEnum? {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
-/// let i8ty :&IntegerType = ctx.getInt8Ty()
+/// let i8ty : &IntegerType = ctx.getInt8Ty()
 /// assert_eq(i8ty.getBitWidth(), 8)
 /// inspect(i8ty.getExtendedType().unwrap(), content="i16")
 /// assert_eq(i8ty.getBitMask(), 0xFF)
 /// assert_eq(i8ty.getExtendedType().unwrap().getSignBit(), 0x8000)
-///
-/// let i32ty = i8ty.getExtendedType().unwrap()
-///                 .getExtendedType().unwrap()
-///
+/// let i32ty = i8ty.getExtendedType().unwrap().getExtendedType().unwrap()
 /// inspect(i32ty, content="i32")
 /// guard i32ty.asIntegerTypeEnum() is Int32Type(i32ty)
 /// inspect(i32ty, content="i32")
@@ -987,7 +983,6 @@ pub impl PrimitiveType for FP128Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getInt1Ty(), content="i1")
 /// ```
 pub struct Int1Type {
@@ -1035,7 +1030,6 @@ pub impl PrimitiveType for Int1Type with asPrimitiveTypeEnum(self) -> PrimitiveT
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getInt8Ty(), content="i8")
 /// ```
 pub struct Int8Type {
@@ -1088,7 +1082,6 @@ pub impl PrimitiveType for Int8Type with asPrimitiveTypeEnum(self) -> PrimitiveT
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getInt16Ty(), content="i16")
 /// ```
 pub struct Int16Type {
@@ -1141,7 +1134,6 @@ pub impl PrimitiveType for Int16Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getInt32Ty(), content="i32")
 /// ```
 pub struct Int32Type {
@@ -1194,7 +1186,6 @@ pub impl PrimitiveType for Int32Type with asPrimitiveTypeEnum(self) -> Primitive
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getInt64Ty(), content="i64")
 /// ```
 pub struct Int64Type {
@@ -1546,15 +1537,12 @@ pub impl AbstractType for FunctionType with asAbstractTypeEnum(self) -> Abstract
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i8ty = ctx.getInt8Ty()
 /// let i16ty = ctx.getInt16Ty()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
-///
 /// let sty = ctx.getStructType([i32ty, f32ty], name="foo")
 /// inspect(sty.full_info(), content="%foo = type { i32, float }")
-///
 /// let sty = ctx.getStructType([i8ty, i16ty], name="bar", isPacked=true)
 /// inspect(sty.full_info(), content="%bar = type <{ i8, i16 }>")
 /// ```
@@ -1613,10 +1601,8 @@ fn StructType::new(
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
-///
 /// let foo = ctx.getStructType([i32ty, f32ty])
 /// let bar = ctx.getStructType([i32ty, f32ty], name="bar")
-///
 /// assert_true(foo.isLiteral())
 /// assert_false(bar.isLiteral())
 /// ```
@@ -1635,7 +1621,6 @@ pub fn StructType::isLiteral(self : StructType) -> Bool {
 /// let ctx = Context::new()
 /// let i32ty = ctx.getInt32Ty()
 /// let f32ty = ctx.getFloatTy()
-///
 /// let foo = ctx.getStructType([], name="foo")
 /// let bar = ctx.getStructType([i32ty, f32ty], name="bar")
 /// assert_true(foo.isOpaque())
@@ -1842,12 +1827,9 @@ pub impl AggregateType for StructType with asAggregateTypeEnum(self) -> Aggregat
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i32ty = ctx.getInt32Ty()
-///
 /// let arrty = ctx.getArrayType(i32ty, 16)
 /// inspect(arrty, content="[16 x i32]")
-///
 /// assert_eq(arrty.getElementCount(), 16)
 /// inspect(arrty.getElementType(), content="i32")
 /// ```
@@ -1919,10 +1901,8 @@ pub impl AggregateType for ArrayType with asAggregateTypeEnum(self) -> Aggregate
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let i32ty = ctx.getInt32Ty()
 /// let vecty = ctx.getFixedVectorType(i32ty, 16)
-///
 /// inspect(vecty, content="<16 x i32>")
 /// assert_eq(vecty.getElementCount(), 16)
 /// inspect(vecty.getElementType(), content="i32")
@@ -2000,10 +1980,8 @@ pub impl AggregateType for VectorType with asAggregateTypeEnum(self) -> Aggregat
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// let f32ty = ctx.getFloatTy()
 /// let vecty = ctx.getScalableVectorType(f32ty, 16)
-///
 /// inspect(vecty, content="<vscale x 16 x float>")
 /// assert_eq(vecty.getElementCount(), 16)
 /// inspect(vecty.getElementType(), content="float")
@@ -2095,16 +2073,12 @@ pub fn AddressSpace::new(v : UInt) -> AddressSpace {
 ///
 /// ```mbt test
 /// let ctx = Context::new()
-///
 /// inspect(ctx.getPtrTy(), content="ptr")
-///
 /// let addressSpace = AddressSpace::new(0)
 /// let ptr = ctx.getPtrTy(addressSpace~)
 /// inspect(ptr, content="ptr")
-///
 /// let i32ty = ctx.getInt32Ty()
 /// assert_true(PointerType::isLoadableOrStorableType(i32ty))
-///
 /// let voidty = ctx.getVoidTy()
 /// assert_false(PointerType::isLoadableOrStorableType(voidty))
 /// ```

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ moon add Kaida-Amethyst/MoonLLVM
 
 A small example that creates a module with an `add` function:
 
-```moonbit
+```mbt check
 fn main {
   // 1. Set up the context and IR builder.
   let ctx = @IR.Context::new()
@@ -413,7 +413,7 @@ moon add Kaida-Amethyst/MoonLLVM
 
 下面是一个最小示例，创建一个 `add` 函数模块：
 
-```moonbit
+```mbt check
 fn main {
   // 1. 创建上下文和 IR builder。
   let ctx = @IR.Context::new()

--- a/doc/constant.mbt.md
+++ b/doc/constant.mbt.md
@@ -29,7 +29,7 @@ int main() {
 
 In Aether, to create a constant integer:
 
-```Moonbit
+```mbt check
 test "Get a constant" {
   let ctx = LLVMContext::new()
 
@@ -48,7 +48,7 @@ to create a constant floating point:
 Notice that for floating point, we have special values, like negative zero,
 negative infinity, nan, we provide some special apis.
 
-```Moonbit
+```mbt check
 test "Get Floating Point Constants" 
   let ctx = LLVMContext::new()
 

--- a/doc/type.mbt.md
+++ b/doc/type.mbt.md
@@ -2,7 +2,7 @@
 
 Initial a new type.
 
-```moonbit
+```mbt check
 ///|
 test "Init Type" {
   let ctx = @IR.Context::new()


### PR DESCRIPTION
- Changed instances of "moonbit" to "mbt check" in README.md and documentation files for consistency.
- Updated example code snippets in README.md to use the new command syntax.
- Revised constant creation examples in constant.mbt.md to align with the new command format.
- Adjusted type initialization examples in type.mbt.md to reflect the updated command usage.
